### PR TITLE
Fix DDM Upgrade Problem

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/upgrade/v1_0_0/UpgradeDynamicDataMapping.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/upgrade/v1_0_0/UpgradeDynamicDataMapping.java
@@ -368,16 +368,6 @@ public class UpgradeDynamicDataMapping extends UpgradeProcess {
 		}
 	}
 
-	protected DDMFormValues getDDMFormValues(
-			long companyId, DDMForm ddmForm, String xml)
-		throws Exception {
-
-		DDMFormValuesXSDDeserializer ddmFormValuesXSDDeserializer =
-			new DDMFormValuesXSDDeserializer(companyId);
-
-		return ddmFormValuesXSDDeserializer.deserialize(ddmForm, xml);
-	}
-
 	protected String getDefaultDDMFormLayoutDefinition(DDMForm ddmForm) {
 		DDMFormLayout ddmFormLayout = DDMUtil.getDefaultDDMFormLayout(ddmForm);
 
@@ -533,8 +523,11 @@ public class UpgradeDynamicDataMapping extends UpgradeProcess {
 				long companyId = rs.getLong("companyId");
 				String xml = rs.getString("data_");
 
-				DDMFormValues ddmFormValues = getDDMFormValues(
-					companyId, ddmForm, xml);
+				DDMFormValuesXSDDeserializer ddmFormValuesXSDDeserializer =
+					new DDMFormValuesXSDDeserializer(companyId);
+
+				DDMFormValues ddmFormValues =
+					ddmFormValuesXSDDeserializer.deserialize(ddmForm, xml);
 
 				String content = toJSON(ddmFormValues);
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/upgrade/v1_0_0/UpgradeDynamicDataMapping.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/upgrade/v1_0_0/UpgradeDynamicDataMapping.java
@@ -16,6 +16,7 @@ package com.liferay.dynamic.data.mapping.upgrade.v1_0_0;
 
 import com.liferay.dynamic.data.mapping.io.DDMFormJSONSerializerUtil;
 import com.liferay.dynamic.data.mapping.io.DDMFormLayoutJSONSerializerUtil;
+import com.liferay.dynamic.data.mapping.io.DDMFormValuesJSONDeserializerUtil;
 import com.liferay.dynamic.data.mapping.io.DDMFormValuesJSONSerializerUtil;
 import com.liferay.dynamic.data.mapping.io.DDMFormXSDDeserializerUtil;
 import com.liferay.dynamic.data.mapping.model.DDMContent;
@@ -670,8 +671,9 @@ public class UpgradeDynamicDataMapping extends UpgradeProcess {
 
 				DDMForm ddmForm = getDDMForm(ddmStructureId);
 
-				DDMFormValues ddmFormValues = getDDMFormValues(
-					companyId, ddmForm, data_);
+				DDMFormValues ddmFormValues =
+					DDMFormValuesJSONDeserializerUtil.deserialize(
+						ddmForm, data_);
 
 				transformFieldTypeDDMFormFields(
 					groupId, companyId, userId, userName, createDate, entryId,
@@ -721,8 +723,9 @@ public class UpgradeDynamicDataMapping extends UpgradeProcess {
 
 				DDMForm ddmForm = getDDMForm(ddmStructureId);
 
-				DDMFormValues ddmFormValues = getDDMFormValues(
-					companyId, ddmForm, data_);
+				DDMFormValues ddmFormValues =
+					DDMFormValuesJSONDeserializerUtil.deserialize(
+						ddmForm, data_);
 
 				transformFieldTypeDDMFormFields(
 					groupId, companyId, userId, userName, createDate, entryId,


### PR DESCRIPTION
Hi @marcellustavares ,

   The log and the steps to reproduce it are in the original ticket https://issues.liferay.com/browse/LPS-62381. 

   The problem is happening because, in the UpgradeDynamicDataMapping class,  the upgradeXMLStorageAdapter method is being executed before the upgradeFieldTypeReferences method, so, the ddmForms are in JSON in the upgradeFieldTypeReferences() method, not in XML.

Thanks in advance,

//cc @migue
