### PR TITLE
Lps 87808

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/resources/com/liferay/portal/workflow/kaleo/dependencies/join-xor-definition.xml
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/resources/com/liferay/portal/workflow/kaleo/dependencies/join-xor-definition.xml
@@ -28,10 +28,34 @@
 				<name>task2</name>
 				<target>task2</target>
 			</transition>
+			<transition>
+				<name>task3</name>
+				<target>task3</target>
+			</transition>
+			<transition>
+				<name>task4</name>
+				<target>task4</target>
+			</transition>
 		</transitions>
 	</fork>
 	<task>
 		<name>task1</name>
+		<actions>
+			<notification>
+				<name>Review Notification</name>
+				<template>${userName} sent you a ${entryType} for review in the workflow.</template>
+				<template-language>freemarker</template-language>
+				<notification-type>email</notification-type>
+				<notification-type>im</notification-type>
+				<notification-type>private-message</notification-type>
+				<notification-type>user-notification</notification-type>
+				<notification-type>push-notification</notification-type>
+				<recipients receptionType="to">
+					<assignees/>
+				</recipients>
+				<execution-type>onAssignment</execution-type>
+			</notification>
+		</actions>
 		<assignments>
 			<roles>
 				<role>
@@ -77,6 +101,144 @@
 	</task>
 	<task>
 		<name>task2</name>
+		<actions>
+			<notification>
+				<name>Review Notification</name>
+				<template>${userName} sent you a ${entryType} for review in the workflow.</template>
+				<template-language>freemarker</template-language>
+				<notification-type>email</notification-type>
+				<notification-type>im</notification-type>
+				<notification-type>private-message</notification-type>
+				<notification-type>user-notification</notification-type>
+				<notification-type>push-notification</notification-type>
+				<recipients receptionType="to">
+					<assignees/>
+				</recipients>
+				<execution-type>onAssignment</execution-type>
+			</notification>
+		</actions>
+		<assignments>
+			<roles>
+				<role>
+					<role-type>organization</role-type>
+					<name>Organization Administrator</name>
+				</role>
+				<role>
+					<role-type>organization</role-type>
+					<name>Organization Content Reviewer</name>
+				</role>
+				<role>
+					<role-type>organization</role-type>
+					<name>Organization Owner</name>
+				</role>
+				<role>
+					<role-type>regular</role-type>
+					<name>Administrator</name>
+				</role>
+				<role>
+					<role-type>regular</role-type>
+					<name>Portal Content Reviewer</name>
+				</role>
+				<role>
+					<role-type>site</role-type>
+					<name>Site Administrator</name>
+				</role>
+				<role>
+					<role-type>site</role-type>
+					<name>Site Content Reviewer</name>
+				</role>
+				<role>
+					<role-type>site</role-type>
+					<name>Site Owner</name>
+				</role>
+			</roles>
+		</assignments>
+		<transitions>
+			<transition>
+				<name>join-xor</name>
+				<target>join-xor</target>
+			</transition>
+		</transitions>
+	</task>
+	<task>
+		<name>task3</name>
+		<actions>
+			<notification>
+				<name>Review Notification</name>
+				<template>${userName} sent you a ${entryType} for review in the workflow.</template>
+				<template-language>freemarker</template-language>
+				<notification-type>email</notification-type>
+				<notification-type>im</notification-type>
+				<notification-type>private-message</notification-type>
+				<notification-type>user-notification</notification-type>
+				<notification-type>push-notification</notification-type>
+				<recipients receptionType="to">
+					<assignees/>
+				</recipients>
+				<execution-type>onAssignment</execution-type>
+			</notification>
+		</actions>
+		<assignments>
+			<roles>
+				<role>
+					<role-type>organization</role-type>
+					<name>Organization Administrator</name>
+				</role>
+				<role>
+					<role-type>organization</role-type>
+					<name>Organization Content Reviewer</name>
+				</role>
+				<role>
+					<role-type>organization</role-type>
+					<name>Organization Owner</name>
+				</role>
+				<role>
+					<role-type>regular</role-type>
+					<name>Administrator</name>
+				</role>
+				<role>
+					<role-type>regular</role-type>
+					<name>Portal Content Reviewer</name>
+				</role>
+				<role>
+					<role-type>site</role-type>
+					<name>Site Administrator</name>
+				</role>
+				<role>
+					<role-type>site</role-type>
+					<name>Site Content Reviewer</name>
+				</role>
+				<role>
+					<role-type>site</role-type>
+					<name>Site Owner</name>
+				</role>
+			</roles>
+		</assignments>
+		<transitions>
+			<transition>
+				<name>join-xor</name>
+				<target>join-xor</target>
+			</transition>
+		</transitions>
+	</task>
+	<task>
+		<name>task4</name>
+		<actions>
+			<notification>
+				<name>Review Notification</name>
+				<template>${userName} sent you a ${entryType} for review in the workflow.</template>
+				<template-language>freemarker</template-language>
+				<notification-type>email</notification-type>
+				<notification-type>im</notification-type>
+				<notification-type>private-message</notification-type>
+				<notification-type>user-notification</notification-type>
+				<notification-type>push-notification</notification-type>
+				<recipients receptionType="to">
+					<assignees/>
+				</recipients>
+				<execution-type>onAssignment</execution-type>
+			</notification>
+		</actions>
 		<assignments>
 			<roles>
 				<role>

--- a/portal-kernel/src/com/liferay/portal/kernel/notifications/BaseUserNotificationHandler.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/notifications/BaseUserNotificationHandler.java
@@ -119,11 +119,15 @@ public abstract class BaseUserNotificationHandler
 
 		UserNotificationDelivery userNotificationDelivery =
 			UserNotificationDeliveryLocalServiceUtil.
-				getUserNotificationDelivery(
+				fetchUserNotificationDelivery(
 					userId, _portletId, classNameId, notificationType,
-					deliveryType, userNotificationDeliveryType.isDefault());
+					deliveryType);
 
-		return userNotificationDelivery.isDeliver();
+		if (userNotificationDelivery != null) {
+			return userNotificationDelivery.isDeliver();
+		}
+
+		return userNotificationDeliveryType.isDefault();
 	}
 
 	@Override


### PR DESCRIPTION
Instead of synchronizing ```isDeliver()```, I stopped calling ```getUserNotificationDelivery()``` which creates a new ```UserNotificationDelivery``` if none exists. We can accomplish the same thing by checking if one already exists and using the default if it doesn't. This passes the steps listed in the ticket, but I wanted to send it back to you in case there's anything else you were testing with.

Also, I don't think your new testcase covers this logic. The test was passing before and after your changes.