### PR TITLE
LPS-90930 [TS]

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v1_4_1/UpgradeKaleoDefinitionVersion.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/upgrade/v1_4_1/UpgradeKaleoDefinitionVersion.java
@@ -84,21 +84,23 @@ public class UpgradeKaleoDefinitionVersion extends UpgradeProcess {
 
 		try (LoggingTimer loggingTimer = new LoggingTimer();
 			PreparedStatement ps1 = connection.prepareStatement(
-				"select name, MAX(version) as version from KaleoDefinition " +
-					"group by name");
+				"select companyId, name, MAX(version) as version from " +
+					"KaleoDefinition group by companyId, name");
 			PreparedStatement ps2 =
 				AutoBatchPreparedStatementUtil.concurrentAutoBatch(
 					connection,
-					"delete from KaleoDefinition where name = ? and version " +
-						"< ?");
+					"delete from KaleoDefinition where companyId = ? and " +
+						"name = ? and version < ?");
 			ResultSet rs = ps1.executeQuery()) {
 
 			while (rs.next()) {
+				long companyId = rs.getLong("companyId");
 				String name = rs.getString("name");
 				int version = rs.getInt("version");
 
-				ps2.setString(1, name);
-				ps2.setInt(2, version);
+				ps2.setLong(1, companyId);
+				ps2.setString(2, name);
+				ps2.setInt(3, version);
 
 				ps2.addBatch();
 			}


### PR DESCRIPTION
Hi @inacionery 

this upgrade is deleting definitions for the same name in other companies and after that the bundleactivator tries to add the default definitions again if they are not found in data base, causing duplicated definition-versions and breaking the index of that table. 
tested and working fine, let me know if you have any doubt!

Best regards,
Jose