### PR TITLE
LPS-91949 My Workflow Tasks cannot be sorted

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/impl/KaleoTaskInstanceTokenLocalServiceImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/impl/KaleoTaskInstanceTokenLocalServiceImpl.java
@@ -803,6 +803,10 @@ public class KaleoTaskInstanceTokenLocalServiceImpl
 		return stream.map(
 			field -> {
 				if (StringUtil.endsWith(field, "date")) {
+					if (field.equals("modifiedDate")) {
+						field = "modified";
+					}
+
 					return new Sort(
 						field, Sort.LONG_TYPE,
 						!orderByComparator.isAscending());


### PR DESCRIPTION
Hey @inacionery 

Could you please review this pull request?

The modification date field is stored in the index as "modified" and "modified_sortable" therefore, the "modifiedDate" sorting parameter won't work.

Thank you and best regards,
István