### PR TITLE
LPS-84450 Filter by userId

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/search/spi/model/query/contributor/KaleoInstanceTokenModelPreFilterContributor.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/internal/search/spi/model/query/contributor/KaleoInstanceTokenModelPreFilterContributor.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.workflow.kaleo.internal.search.spi.model.query.contributor;
 
 import com.liferay.portal.kernel.search.BooleanClauseOccur;
+import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.filter.BooleanFilter;
 import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
@@ -64,6 +65,7 @@ public class KaleoInstanceTokenModelPreFilterContributor
 		appendKaleoInstanceTokenIdTerm(booleanFilter, kaleoInstanceTokenQuery);
 		appendParentKaleoInstanceTokenIdTerm(
 			booleanFilter, kaleoInstanceTokenQuery);
+		appendUserIdTerm(booleanFilter, kaleoInstanceTokenQuery);
 	}
 
 	protected void appendCompletedTerm(
@@ -157,6 +159,19 @@ public class KaleoInstanceTokenModelPreFilterContributor
 		booleanFilter.addRequiredTerm(
 			KaleoInstanceTokenField.PARENT_KALEO_INSTANCE_TOKEN_ID,
 			parentKaleoInstanceTokenId);
+	}
+
+	protected void appendUserIdTerm(
+		BooleanFilter booleanFilter,
+		KaleoInstanceTokenQuery kaleoInstanceTokenQuery) {
+
+		Long userId = kaleoInstanceTokenQuery.getUserId();
+
+		if (userId == null) {
+			return;
+		}
+
+		booleanFilter.addRequiredTerm(Field.USER_ID, userId);
 	}
 
 	@Reference

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/impl/KaleoInstanceLocalServiceImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-service/src/main/java/com/liferay/portal/workflow/kaleo/service/impl/KaleoInstanceLocalServiceImpl.java
@@ -335,6 +335,8 @@ public class KaleoInstanceLocalServiceImpl
 		try {
 			List<KaleoInstance> kaleoInstances = new ArrayList<>();
 
+			serviceContext.setUserId(userId);
+
 			Hits hits = kaleoInstanceTokenLocalService.search(
 				assetClassName, assetTitle, assetDescription, nodeName,
 				kaleoDefinitionName, completed, start, end,
@@ -381,6 +383,8 @@ public class KaleoInstanceLocalServiceImpl
 		Long userId, String assetClassName, String assetTitle,
 		String assetDescription, String nodeName, String kaleoDefinitionName,
 		Boolean completed, ServiceContext serviceContext) {
+
+		serviceContext.setUserId(userId);
 
 		return kaleoInstanceTokenLocalService.searchCount(
 			assetClassName, assetTitle, assetDescription, nodeName,


### PR DESCRIPTION
Hey @inacionery 

I'm sorry, but I had to reopen [LPS-84450](https://issues.liferay.com/browse/LPS-84450) to add a small correction.
The dynamicQuery based search filtered by userId while the index based search didn't, and one of the backport test cases caught this.

Could you please check it?

Thank you and best regards,
István