### PR TITLE
LPS-91985 Element IDs have their special characters replaced

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -1167,7 +1167,7 @@ AUI.add(
 
 						var parsedValue = instance.getParsedValue(instance.getValue());
 
-						var titleNode = A.one('#' + instance.getInputName() + 'Title');
+						var titleNode = A.one('input[name=' + instance.getInputName() + 'Title]');
 
 						titleNode.val(parsedValue.title || '');
 
@@ -1372,7 +1372,7 @@ AUI.add(
 
 						var parsedValue = instance.getParsedValue(instance.getValue());
 
-						var titleNode = A.one('#' + instance.getInputName() + 'Title');
+						var titleNode = A.one('input[name=' + instance.getInputName() + 'Title]');
 
 						titleNode.val(parsedValue.title || '');
 
@@ -1634,7 +1634,7 @@ AUI.add(
 
 						var inputName = instance.getInputName();
 
-						var layoutNameNode = container.one('#' + inputName + 'LayoutName');
+						var layoutNameNode = container.one('input[name=' + inputName + 'LayoutName]');
 
 						var parsedValue = instance.getParsedValue(value);
 
@@ -2562,11 +2562,11 @@ AUI.add(
 
 						var notEmpty = instance.isNotEmpty(parsedValue);
 
-						var altNode = A.one('#' + instance.getInputName() + 'Alt');
+						var altNode = A.one('input[name=' + instance.getInputName() + 'Alt]');
 
 						altNode.attr('disabled', !notEmpty);
 
-						var titleNode = A.one('#' + instance.getInputName() + 'Title');
+						var titleNode = A.one('input[name=' + instance.getInputName() + 'Title]');
 
 						if (notEmpty) {
 							altNode.val(parsedValue.alt || '');
@@ -2645,7 +2645,7 @@ AUI.add(
 						var parsedValue = instance.getParsedValue(ImageField.superclass.getValue.apply(instance, arguments));
 
 						if (instance.isNotEmpty(parsedValue)) {
-							var altNode = A.one('#' + instance.getInputName() + 'Alt');
+							var altNode = A.one('input[name=' + instance.getInputName() + 'Alt]');
 
 							parsedValue.alt = altNode.val();
 
@@ -2676,7 +2676,7 @@ AUI.add(
 								parsedValue.name = parsedValue.title;
 							}
 
-							var altNode = A.one('#' + instance.getInputName() + 'Alt');
+							var altNode = A.one('input[name=' + instance.getInputName() + 'Alt]');
 
 							altNode.val(parsedValue.alt);
 
@@ -2790,7 +2790,7 @@ AUI.add(
 							)
 						);
 
-						var locationNode = A.one('#' + inputName + 'Location');
+						var locationNode = A.one('input[name=' + inputName + 'Location]');
 
 						locationNode.html(event.newVal.address);
 					}


### PR DESCRIPTION
Hey @inacionery 

I have added a correction to [LPS-91985](https://issues.liferay.com/browse/LPS-91985)

The **id** attribute of the `input` fields in the rendered DDM fields does not allow non-ASCII characters (á, é, ó, ú and the like), and they will be converted to a dash (-).

I changed the node selector criteria to **name**,  as non-ASCII characters are retained in that attribute's value.

Could you please check it?

Thank you and best regards,
István