### PR TITLE
LPS-91093

### DIFF
--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarBookingLocalServiceImpl.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarBookingLocalServiceImpl.java
@@ -275,6 +275,11 @@ public class CalendarBookingLocalServiceImpl
 				serviceContext);
 		}
 
+		calendarBooking.setCreateDate(serviceContext.getCreateDate(now));
+		calendarBooking.setModifiedDate(serviceContext.getModifiedDate(now));
+
+		calendarBookingPersistence.update(calendarBooking);
+
 		return calendarBooking;
 	}
 

--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarBookingLocalServiceImpl.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarBookingLocalServiceImpl.java
@@ -1609,6 +1609,7 @@ public class CalendarBookingLocalServiceImpl
 		User user = userLocalService.getUser(userId);
 		Date now = new Date();
 
+		Date oldModifiedDate = calendarBooking.getModifiedDate();
 		int oldStatus = calendarBooking.getStatus();
 
 		calendarBooking.setModifiedDate(serviceContext.getModifiedDate(now));
@@ -1679,10 +1680,43 @@ public class CalendarBookingLocalServiceImpl
 						calendarBooking.getUuid(), null,
 						WorkflowConstants.STATUS_PENDING, null, null);
 				}
+			}
+		}
 
-				sendNotification(
-					calendarBooking, NotificationTemplateType.MOVED_TO_TRASH,
-					serviceContext);
+		if (calendarBooking.isMasterBooking()) {
+			Date createDate = calendarBooking.getCreateDate();
+
+			NotificationTemplateType notificationTemplateType =
+				NotificationTemplateType.INVITE;
+
+			if (createDate.getTime() != oldModifiedDate.getTime()) {
+				notificationTemplateType = NotificationTemplateType.UPDATE;
+			}
+
+			for (CalendarBooking childCalendarBooking : childCalendarBookings) {
+				if (childCalendarBooking.equals(calendarBooking)) {
+					continue;
+				}
+
+				if (childCalendarBooking.isDenied()) {
+					notificationTemplateType = NotificationTemplateType.DECLINE;
+				}
+
+				if (calendarBooking.isApproved()) {
+					sendNotification(
+						childCalendarBooking, notificationTemplateType,
+						serviceContext);
+				}
+				else if ((oldStatus == WorkflowConstants.STATUS_APPROVED) &&
+						 (status == WorkflowConstants.STATUS_IN_TRASH)) {
+
+					notificationTemplateType =
+						NotificationTemplateType.MOVED_TO_TRASH;
+
+					sendNotification(
+						childCalendarBooking, notificationTemplateType,
+						serviceContext);
+				}
 			}
 		}
 
@@ -1816,21 +1850,6 @@ public class CalendarBookingLocalServiceImpl
 						oldChildCalendarBooking.getStatus(), serviceContext);
 				}
 			}
-
-			NotificationTemplateType notificationTemplateType =
-				NotificationTemplateType.INVITE;
-
-			if (childCalendarBooking.isDenied()) {
-				notificationTemplateType = NotificationTemplateType.DECLINE;
-			}
-			else if (childCalendarBookingMap.containsKey(
-						childCalendarBooking.getCalendarId())) {
-
-				notificationTemplateType = NotificationTemplateType.UPDATE;
-			}
-
-			sendNotification(
-				childCalendarBooking, notificationTemplateType, serviceContext);
 		}
 	}
 

--- a/modules/apps/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/service/test/CalendarBookingLocalServiceTest.java
+++ b/modules/apps/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/service/test/CalendarBookingLocalServiceTest.java
@@ -1326,6 +1326,37 @@ public class CalendarBookingLocalServiceTest {
 	}
 
 	@Test
+	public void testInviteUserCalendarWithWorkflowShouldNotifieInviteCalendarBookingOnlyAfterApprovedAndPublished()
+		throws Exception {
+
+		_group = GroupTestUtil.addGroup();
+
+		CalendarWorkflowTestUtil.activateWorkflow(_group);
+
+		_invitingUser = UserTestUtil.addUser();
+
+		Calendar invitedCalendar = CalendarTestUtil.addCalendar(_invitingUser);
+
+		Calendar invitingCalendar = CalendarTestUtil.getDefaultCalendar(_group);
+
+		CalendarBooking calendarBooking =
+			CalendarBookingTestUtil.addMasterCalendarBookingWithWorkflow(
+				invitingCalendar, invitedCalendar,
+				WorkflowConstants.ACTION_PUBLISH);
+
+		String mailMessageSubject =
+			"Calendar: Event Notification for " + StringPool.QUOTE +
+				calendarBooking.getTitle(LocaleUtil.getDefault()) +
+					StringPool.QUOTE;
+
+		assertMailSubjectCount(mailMessageSubject, 0);
+
+		CalendarWorkflowTestUtil.completeWorkflow(_group);
+
+		assertMailSubjectCount(mailMessageSubject, 1);
+	}
+
+	@Test
 	public void testInviteUserResourceCalendar() throws Exception {
 		ServiceContext serviceContext = createServiceContext();
 

--- a/modules/apps/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/test/util/CalendarBookingTestUtil.java
+++ b/modules/apps/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/test/util/CalendarBookingTestUtil.java
@@ -227,7 +227,8 @@ public class CalendarBookingTestUtil {
 			int actionPublish)
 		throws PortalException {
 
-		User user = UserLocalServiceUtil.fetchUser(invitedCalendar.getUserId());
+		User user = UserLocalServiceUtil.fetchUser(
+			invitingCalendar.getUserId());
 		long startTime = System.currentTimeMillis();
 
 		ServiceContext serviceContext = createServiceContext(user);


### PR DESCRIPTION
Hello @inacionery ,

I was able to achieve our intended result without altering your created test.

The reason this commit is required: 50966d2  is because the user needs to be the user that is doing the invite action, not the user who is being invited.

Using the invited user will incorrectly assign calendarResource for each childCalendar which is why the initial assertMail check was failing.

Sincerely,
Brian Kim

cc/@rafaprax