### PR TITLE
LPS-95658 Calendar: not possible to only show current day's events in agenda view

### DIFF
--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/configuration/display_settings.jspf
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/configuration/display_settings.jspf
@@ -33,6 +33,7 @@
 
 	<aui:fieldset>
 		<aui:select label="maximum-days-to-display" name="maxDaysDisplayed" value="<%= maxDaysDisplayed %>">
+			<aui:option label="0" value="<%= 0 %>" />
 			<aui:option label="1" value="<%= 1 %>" />
 			<aui:option label="2" value="<%= 2 %>" />
 			<aui:option label="3" value="<%= 3 %>" />


### PR DESCRIPTION
Hey @inacionery 

Could you please review this pull request?

The behavior is caused by the "Maximum Days to Display" option from Configuration/Display Settings, which determines how many days in advance should events we shown. 
This value can only be set to 1, 2, 3, 4 or 5. But it cannot be set to 0, so in all cases, events of the subsequent day will be shown, not only of the current day.

By enabling the "Maximum Days to Display" to be set to 0 (while keeping 1 as the default), this confusing behavior can be prevented.

Please let me know what you think of this.

Thank you and best regards,
István