### PR TITLE
LPS-97984 Add init-ext.jsp extension point to calendar web

### DIFF
--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/init-ext.jsp
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/init-ext.jsp
@@ -1,0 +1,15 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>

--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/init.jsp
@@ -245,3 +245,5 @@ else {
 	dateFormatTime = FastDateFormatFactoryUtil.getSimpleDateFormat("hh:mm a", locale, userTimeZone);
 }
 %>
+
+<%@ include file="/init-ext.jsp" %>


### PR DESCRIPTION
This pull request is for https://issues.liferay.com/browse/LPS-97984.
Could you please take a look at this?

A customer wants to customize the init.jsp of calendar-web. Because it imports internal classes it is not possible to do it directly so this init-ext.jsp extension point is necessary. Considering there are init-ext.jsps pretty much everywhere else we considered (the lack of) it a bug.
Thank you very much