### PR TITLE
LPS-100463 Getting PortletURL from the same context. As a fallback we'll keep Control Panel URL

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/workflow/BaseWorkflowHandler.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/workflow/BaseWorkflowHandler.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.WorkflowDefinitionLink;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
+import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalServiceUtil;
 import com.liferay.portal.kernel.service.WorkflowInstanceLinkLocalServiceUtil;
@@ -155,9 +156,15 @@ public abstract class BaseWorkflowHandler<T> implements WorkflowHandler<T> {
 		throws PortalException {
 
 		try {
-			PortletURL portletURL = PortalUtil.getControlPanelPortletURL(
+			PortletURL portletURL = PortletURLFactoryUtil.create(
 				serviceContext.getRequest(), PortletKeys.MY_WORKFLOW_TASK,
 				PortletRequest.RENDER_PHASE);
+
+			if (portletURL == null) {
+				portletURL = PortalUtil.getControlPanelPortletURL(
+					serviceContext.getRequest(), PortletKeys.MY_WORKFLOW_TASK,
+					PortletRequest.RENDER_PHASE);
+			}
 
 			portletURL.setParameter("mvcPath", "/edit_workflow_task.jsp");
 			portletURL.setParameter(


### PR DESCRIPTION
Hi @inacionery ,

Following the conversation started in rafaprax#965 and answering your questions:

> but I'm not understanding the fix, PortletURLFactoryUtil.create is returning null? Because as far as I know, it should not return null. I don't have access to the Zendesk ticket, could you please tell me exactly what the customer's complaint is? Once the Workflow Task Portlet is a portlet of Control Panel, it should be opened with the theme and URL of the Control Panel.

Customer's complaint is the context change. I mean, when they are seeing the notification they are in context **/web/guest/manage**, but if they access to notifications related to Workflow Task the context would be **/group/control_panel/manage**. That means that if you, i.e., try to go back using the button back in Control Menu bar (not the button in the browser) you wouldn't be redirected to the notifications list. Instead of that you are redirected to the list of task assigned to yourself in Workflow Task Portlet.  This is just one of the effects of the big issue which is the context change.

I hope this helps you to better understand the motivation behind my change. Anyway, I'm not an expert about Workflow Task Portlet, but I can understand that if this is a Control Panel Portlet, then we should always show it under Control Panel context. Would make sense in that case to get rid of the back button in Control Menu bar for this portlet? In that way, we could avoid confusion among customer due to context changes, at least, for that case.

Thanks.

Regards.