### PR TITLE
Lps 99515

### DIFF
--- a/modules/apps/document-library/document-library-uad-test/src/testIntegration/java/com/liferay/document/library/uad/anonymizer/test/DLFileEntryTypeUADAnonymizerTest.java
+++ b/modules/apps/document-library/document-library-uad-test/src/testIntegration/java/com/liferay/document/library/uad/anonymizer/test/DLFileEntryTypeUADAnonymizerTest.java
@@ -18,19 +18,20 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.document.library.kernel.model.DLFileEntryType;
 import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalService;
 import com.liferay.document.library.uad.test.DLFileEntryTypeUADTestUtil;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.user.associated.data.anonymizer.UADAnonymizer;
 import com.liferay.user.associated.data.test.util.BaseUADAnonymizerTestCase;
 
-import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.After;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
@@ -47,10 +48,12 @@ public class DLFileEntryTypeUADAnonymizerTest
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
 
-	@After
-	public void tearDown() throws Exception {
-		DLFileEntryTypeUADTestUtil.cleanUpDependencies(
-			_dlFileEntryTypeLocalService, _portal, _dlFileEntryTypes);
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+
+		_group = GroupTestUtil.addGroup();
 	}
 
 	@Override
@@ -63,15 +66,8 @@ public class DLFileEntryTypeUADAnonymizerTest
 			long userId, boolean deleteAfterTestRun)
 		throws Exception {
 
-		DLFileEntryType dlFileEntryType =
-			DLFileEntryTypeUADTestUtil.addDLFileEntryType(
-				_dlFileEntryTypeLocalService, _portal, userId);
-
-		if (deleteAfterTestRun) {
-			_dlFileEntryTypes.add(dlFileEntryType);
-		}
-
-		return dlFileEntryType;
+		return DLFileEntryTypeUADTestUtil.addDLFileEntryType(
+			_dlFileEntryTypeLocalService, _portal, userId, _group.getGroupId());
 	}
 
 	@Override
@@ -120,7 +116,7 @@ public class DLFileEntryTypeUADAnonymizerTest
 	private DLFileEntryTypeLocalService _dlFileEntryTypeLocalService;
 
 	@DeleteAfterTestRun
-	private final List<DLFileEntryType> _dlFileEntryTypes = new ArrayList<>();
+	private Group _group;
 
 	@Inject
 	private Portal _portal;

--- a/modules/apps/document-library/document-library-uad-test/src/testIntegration/java/com/liferay/document/library/uad/anonymizer/test/DLFileEntryUADAnonymizerTest.java
+++ b/modules/apps/document-library/document-library-uad-test/src/testIntegration/java/com/liferay/document/library/uad/anonymizer/test/DLFileEntryUADAnonymizerTest.java
@@ -30,9 +30,12 @@ import com.liferay.message.boards.constants.MBCategoryConstants;
 import com.liferay.message.boards.model.MBMessage;
 import com.liferay.message.boards.service.MBThreadLocalService;
 import com.liferay.message.boards.test.util.MBTestUtil;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
@@ -44,11 +47,10 @@ import com.liferay.user.associated.data.test.util.BaseHasAssetEntryUADAnonymizer
 
 import java.io.InputStream;
 
-import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -66,13 +68,12 @@ public class DLFileEntryUADAnonymizerTest
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
 
-	@After
-	public void tearDown() throws Exception {
-		DLFileEntryUADTestUtil.cleanUpDependencies(
-			_dlAppLocalService, _dlFileEntryLocalService, _dlFolderLocalService,
-			_dlFileEntries);
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
 
-		_dlFileEntries.clear();
+		_group = GroupTestUtil.addGroup();
 	}
 
 	@Test
@@ -178,15 +179,9 @@ public class DLFileEntryUADAnonymizerTest
 	protected DLFileEntry addBaseModel(long userId, boolean deleteAfterTestRun)
 		throws Exception {
 
-		DLFileEntry dlFileEntry = DLFileEntryUADTestUtil.addDLFileEntry(
+		return DLFileEntryUADTestUtil.addDLFileEntry(
 			_dlAppLocalService, _dlFileEntryLocalService, _dlFolderLocalService,
-			userId);
-
-		if (deleteAfterTestRun) {
-			_dlFileEntries.add(dlFileEntry);
-		}
-
-		return dlFileEntry;
+			userId, _group.getGroupId());
 	}
 
 	@Override
@@ -282,13 +277,14 @@ public class DLFileEntryUADAnonymizerTest
 	@Inject
 	private DLAppLocalService _dlAppLocalService;
 
-	private final List<DLFileEntry> _dlFileEntries = new ArrayList<>();
-
 	@Inject
 	private DLFileEntryLocalService _dlFileEntryLocalService;
 
 	@Inject
 	private DLFolderLocalService _dlFolderLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
 
 	@Inject
 	private MBThreadLocalService _mbThreadLocalService;

--- a/modules/apps/document-library/document-library-uad-test/src/testIntegration/java/com/liferay/document/library/uad/anonymizer/test/DLFileShortcutUADAnonymizerTest.java
+++ b/modules/apps/document-library/document-library-uad-test/src/testIntegration/java/com/liferay/document/library/uad/anonymizer/test/DLFileShortcutUADAnonymizerTest.java
@@ -20,19 +20,20 @@ import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
 import com.liferay.document.library.kernel.service.DLFileShortcutLocalService;
 import com.liferay.document.library.kernel.service.DLFolderLocalService;
 import com.liferay.document.library.uad.test.DLFileShortcutUADTestUtil;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.user.associated.data.anonymizer.UADAnonymizer;
 import com.liferay.user.associated.data.test.util.BaseHasAssetEntryUADAnonymizerTestCase;
 import com.liferay.user.associated.data.test.util.WhenHasStatusByUserIdField;
 
-import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.After;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
@@ -55,20 +56,17 @@ public class DLFileShortcutUADAnonymizerTest
 			long userId, long statusByUserId)
 		throws Exception {
 
-		DLFileShortcut dlFileShortcut =
-			DLFileShortcutUADTestUtil.addDLFileShortcutWithStatusByUserId(
-				_dlFileEntryLocalService, _dlFileShortcutLocalService,
-				_dlFolderLocalService, userId, statusByUserId);
-
-		_dlFileShortcuts.add(dlFileShortcut);
-
-		return dlFileShortcut;
+		return DLFileShortcutUADTestUtil.addDLFileShortcutWithStatusByUserId(
+			_dlFileEntryLocalService, _dlFileShortcutLocalService,
+			_dlFolderLocalService, userId, _group.getGroupId(), statusByUserId);
 	}
 
-	@After
-	public void tearDown() throws Exception {
-		DLFileShortcutUADTestUtil.cleanUpDependencies(
-			_dlFileEntryLocalService, _dlFolderLocalService, _dlFileShortcuts);
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+
+		_group = GroupTestUtil.addGroup();
 	}
 
 	@Override
@@ -81,16 +79,9 @@ public class DLFileShortcutUADAnonymizerTest
 			long userId, boolean deleteAfterTestRun)
 		throws Exception {
 
-		DLFileShortcut dlFileShortcut =
-			DLFileShortcutUADTestUtil.addDLFileShortcut(
-				_dlFileEntryLocalService, _dlFileShortcutLocalService,
-				_dlFolderLocalService, userId);
-
-		if (deleteAfterTestRun) {
-			_dlFileShortcuts.add(dlFileShortcut);
-		}
-
-		return dlFileShortcut;
+		return DLFileShortcutUADTestUtil.addDLFileShortcut(
+			_dlFileEntryLocalService, _dlFileShortcutLocalService,
+			_dlFolderLocalService, userId, _group.getGroupId());
 	}
 
 	@Override
@@ -147,11 +138,11 @@ public class DLFileShortcutUADAnonymizerTest
 	@Inject
 	private DLFileShortcutLocalService _dlFileShortcutLocalService;
 
-	@DeleteAfterTestRun
-	private final List<DLFileShortcut> _dlFileShortcuts = new ArrayList<>();
-
 	@Inject
 	private DLFolderLocalService _dlFolderLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
 
 	@Inject(filter = "component.name=*.DLFileShortcutUADAnonymizer")
 	private UADAnonymizer _uadAnonymizer;

--- a/modules/apps/document-library/document-library-uad-test/src/testIntegration/java/com/liferay/document/library/uad/anonymizer/test/DLFolderUADAnonymizerTest.java
+++ b/modules/apps/document-library/document-library-uad-test/src/testIntegration/java/com/liferay/document/library/uad/anonymizer/test/DLFolderUADAnonymizerTest.java
@@ -19,18 +19,18 @@ import com.liferay.document.library.kernel.model.DLFolder;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.kernel.service.DLFolderLocalService;
 import com.liferay.document.library.uad.test.DLFolderUADTestUtil;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.user.associated.data.anonymizer.UADAnonymizer;
 import com.liferay.user.associated.data.test.util.BaseHasAssetEntryUADAnonymizerTestCase;
 import com.liferay.user.associated.data.test.util.WhenHasStatusByUserIdField;
 
-import java.util.ArrayList;
-import java.util.List;
-
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -54,26 +54,28 @@ public class DLFolderUADAnonymizerTest
 			long userId, long statusByUserId)
 		throws Exception {
 
-		DLFolder dlFolder = DLFolderUADTestUtil.addDLFolderWithStatusByUserId(
-			_dlAppLocalService, _dlFolderLocalService, userId, statusByUserId);
+		return DLFolderUADTestUtil.addDLFolderWithStatusByUserId(
+			_dlAppLocalService, _dlFolderLocalService, userId,
+			_group.getGroupId(), statusByUserId);
+	}
 
-		_dlFolders.add(dlFolder);
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
 
-		return dlFolder;
+		_group = GroupTestUtil.addGroup();
 	}
 
 	@Test
 	public void testDeleteDependentFolders() throws Exception {
 		DLFolder parentDLFolder = DLFolderUADTestUtil.addDLFolder(
-			_dlAppLocalService, _dlFolderLocalService, user.getUserId());
-
-		_dlFolders.add(parentDLFolder);
+			_dlAppLocalService, _dlFolderLocalService, user.getUserId(),
+			_group.getGroupId());
 
 		DLFolder childDLFolder = DLFolderUADTestUtil.addDLFolder(
 			_dlAppLocalService, _dlFolderLocalService, user.getUserId(),
-			parentDLFolder.getFolderId());
-
-		_dlFolders.add(childDLFolder);
+			_group.getGroupId(), parentDLFolder.getFolderId());
 
 		_uadAnonymizer.delete(parentDLFolder);
 
@@ -89,14 +91,9 @@ public class DLFolderUADAnonymizerTest
 	protected DLFolder addBaseModel(long userId, boolean deleteAfterTestRun)
 		throws Exception {
 
-		DLFolder dlFolder = DLFolderUADTestUtil.addDLFolder(
-			_dlAppLocalService, _dlFolderLocalService, userId);
-
-		if (deleteAfterTestRun) {
-			_dlFolders.add(dlFolder);
-		}
-
-		return dlFolder;
+		return DLFolderUADTestUtil.addDLFolder(
+			_dlAppLocalService, _dlFolderLocalService, userId,
+			_group.getGroupId());
 	}
 
 	@Override
@@ -142,7 +139,7 @@ public class DLFolderUADAnonymizerTest
 	private DLFolderLocalService _dlFolderLocalService;
 
 	@DeleteAfterTestRun
-	private final List<DLFolder> _dlFolders = new ArrayList<>();
+	private Group _group;
 
 	@Inject(filter = "component.name=*.DLFolderUADAnonymizer")
 	private UADAnonymizer _uadAnonymizer;

--- a/modules/apps/document-library/document-library-uad-test/src/testIntegration/java/com/liferay/document/library/uad/exporter/test/DLFileEntryTypeUADExporterTest.java
+++ b/modules/apps/document-library/document-library-uad-test/src/testIntegration/java/com/liferay/document/library/uad/exporter/test/DLFileEntryTypeUADExporterTest.java
@@ -18,18 +18,17 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.document.library.kernel.model.DLFileEntryType;
 import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalService;
 import com.liferay.document.library.uad.test.DLFileEntryTypeUADTestUtil;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.user.associated.data.exporter.UADExporter;
 import com.liferay.user.associated.data.test.util.BaseUADExporterTestCase;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import org.junit.After;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
@@ -46,21 +45,18 @@ public class DLFileEntryTypeUADExporterTest
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
 
-	@After
-	public void tearDown() throws Exception {
-		DLFileEntryTypeUADTestUtil.cleanUpDependencies(
-			_dlFileEntryTypeLocalService, _portal, _dlFileEntryTypes);
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+
+		_group = GroupTestUtil.addGroup();
 	}
 
 	@Override
 	protected DLFileEntryType addBaseModel(long userId) throws Exception {
-		DLFileEntryType dlFileEntryType =
-			DLFileEntryTypeUADTestUtil.addDLFileEntryType(
-				_dlFileEntryTypeLocalService, _portal, userId);
-
-		_dlFileEntryTypes.add(dlFileEntryType);
-
-		return dlFileEntryType;
+		return DLFileEntryTypeUADTestUtil.addDLFileEntryType(
+			_dlFileEntryTypeLocalService, _portal, userId, _group.getGroupId());
 	}
 
 	@Override
@@ -77,7 +73,7 @@ public class DLFileEntryTypeUADExporterTest
 	private DLFileEntryTypeLocalService _dlFileEntryTypeLocalService;
 
 	@DeleteAfterTestRun
-	private final List<DLFileEntryType> _dlFileEntryTypes = new ArrayList<>();
+	private Group _group;
 
 	@Inject
 	private Portal _portal;

--- a/modules/apps/document-library/document-library-uad-test/src/testIntegration/java/com/liferay/document/library/uad/exporter/test/DLFileEntryUADExporterTest.java
+++ b/modules/apps/document-library/document-library-uad-test/src/testIntegration/java/com/liferay/document/library/uad/exporter/test/DLFileEntryUADExporterTest.java
@@ -20,8 +20,10 @@ import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
 import com.liferay.document.library.kernel.service.DLFolderLocalService;
 import com.liferay.document.library.uad.test.DLFileEntryUADTestUtil;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.zip.ZipReader;
 import com.liferay.portal.kernel.zip.ZipReaderFactoryUtil;
 import com.liferay.portal.test.rule.Inject;
@@ -31,11 +33,10 @@ import com.liferay.user.associated.data.test.util.BaseUADExporterTestCase;
 
 import java.io.File;
 
-import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -53,11 +54,12 @@ public class DLFileEntryUADExporterTest
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
 
-	@After
-	public void tearDown() throws Exception {
-		DLFileEntryUADTestUtil.cleanUpDependencies(
-			_dlAppLocalService, _dlFileEntryLocalService, _dlFolderLocalService,
-			_dlFileEntries);
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+
+		_group = GroupTestUtil.addGroup();
 	}
 
 	@Override
@@ -76,13 +78,9 @@ public class DLFileEntryUADExporterTest
 
 	@Override
 	protected DLFileEntry addBaseModel(long userId) throws Exception {
-		DLFileEntry dlFileEntry = DLFileEntryUADTestUtil.addDLFileEntry(
+		return DLFileEntryUADTestUtil.addDLFileEntry(
 			_dlAppLocalService, _dlFileEntryLocalService, _dlFolderLocalService,
-			userId);
-
-		_dlFileEntries.add(dlFileEntry);
-
-		return dlFileEntry;
+			userId, _group.getGroupId());
 	}
 
 	@Override
@@ -98,14 +96,14 @@ public class DLFileEntryUADExporterTest
 	@Inject
 	private DLAppLocalService _dlAppLocalService;
 
-	@DeleteAfterTestRun
-	private final List<DLFileEntry> _dlFileEntries = new ArrayList<>();
-
 	@Inject
 	private DLFileEntryLocalService _dlFileEntryLocalService;
 
 	@Inject
 	private DLFolderLocalService _dlFolderLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
 
 	@Inject(filter = "component.name=*.DLFileEntryUADExporter")
 	private UADExporter _uadExporter;

--- a/modules/apps/document-library/document-library-uad-test/src/testIntegration/java/com/liferay/document/library/uad/exporter/test/DLFileShortcutUADExporterTest.java
+++ b/modules/apps/document-library/document-library-uad-test/src/testIntegration/java/com/liferay/document/library/uad/exporter/test/DLFileShortcutUADExporterTest.java
@@ -20,18 +20,17 @@ import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
 import com.liferay.document.library.kernel.service.DLFileShortcutLocalService;
 import com.liferay.document.library.kernel.service.DLFolderLocalService;
 import com.liferay.document.library.uad.test.DLFileShortcutUADTestUtil;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.user.associated.data.exporter.UADExporter;
 import com.liferay.user.associated.data.test.util.BaseUADExporterTestCase;
 import com.liferay.user.associated.data.test.util.WhenHasStatusByUserIdField;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import org.junit.After;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
@@ -57,32 +56,24 @@ public class DLFileShortcutUADExporterTest
 			long userId, long statusByUserId)
 		throws Exception {
 
-		DLFileShortcut dlFileShortcut =
-			DLFileShortcutUADTestUtil.addDLFileShortcutWithStatusByUserId(
-				_dlFileEntryLocalService, _dlFileShortcutLocalService,
-				_dlFolderLocalService, userId, statusByUserId);
-
-		_dlFileShortcuts.add(dlFileShortcut);
-
-		return dlFileShortcut;
+		return DLFileShortcutUADTestUtil.addDLFileShortcutWithStatusByUserId(
+			_dlFileEntryLocalService, _dlFileShortcutLocalService,
+			_dlFolderLocalService, userId, _group.getGroupId(), statusByUserId);
 	}
 
-	@After
-	public void tearDown() throws Exception {
-		DLFileShortcutUADTestUtil.cleanUpDependencies(
-			_dlFileEntryLocalService, _dlFolderLocalService, _dlFileShortcuts);
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+
+		_group = GroupTestUtil.addGroup();
 	}
 
 	@Override
 	protected DLFileShortcut addBaseModel(long userId) throws Exception {
-		DLFileShortcut dlFileShortcut =
-			DLFileShortcutUADTestUtil.addDLFileShortcut(
-				_dlFileEntryLocalService, _dlFileShortcutLocalService,
-				_dlFolderLocalService, userId);
-
-		_dlFileShortcuts.add(dlFileShortcut);
-
-		return dlFileShortcut;
+		return DLFileShortcutUADTestUtil.addDLFileShortcut(
+			_dlFileEntryLocalService, _dlFileShortcutLocalService,
+			_dlFolderLocalService, userId, _group.getGroupId());
 	}
 
 	@Override
@@ -101,11 +92,11 @@ public class DLFileShortcutUADExporterTest
 	@Inject
 	private DLFileShortcutLocalService _dlFileShortcutLocalService;
 
-	@DeleteAfterTestRun
-	private final List<DLFileShortcut> _dlFileShortcuts = new ArrayList<>();
-
 	@Inject
 	private DLFolderLocalService _dlFolderLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
 
 	@Inject(filter = "component.name=*.DLFileShortcutUADExporter")
 	private UADExporter _uadExporter;

--- a/modules/apps/document-library/document-library-uad-test/src/testIntegration/java/com/liferay/document/library/uad/exporter/test/DLFolderUADExporterTest.java
+++ b/modules/apps/document-library/document-library-uad-test/src/testIntegration/java/com/liferay/document/library/uad/exporter/test/DLFolderUADExporterTest.java
@@ -19,17 +19,17 @@ import com.liferay.document.library.kernel.model.DLFolder;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.kernel.service.DLFolderLocalService;
 import com.liferay.document.library.uad.test.DLFolderUADTestUtil;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.user.associated.data.exporter.UADExporter;
 import com.liferay.user.associated.data.test.util.BaseUADExporterTestCase;
 import com.liferay.user.associated.data.test.util.WhenHasStatusByUserIdField;
 
-import java.util.ArrayList;
-import java.util.List;
-
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
@@ -52,22 +52,24 @@ public class DLFolderUADExporterTest
 			long userId, long statusByUserId)
 		throws Exception {
 
-		DLFolder dlFolder = DLFolderUADTestUtil.addDLFolderWithStatusByUserId(
-			_dlAppLocalService, _dlFolderLocalService, userId, statusByUserId);
+		return DLFolderUADTestUtil.addDLFolderWithStatusByUserId(
+			_dlAppLocalService, _dlFolderLocalService, userId,
+			_group.getGroupId(), statusByUserId);
+	}
 
-		_dlFolders.add(dlFolder);
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
 
-		return dlFolder;
+		_group = GroupTestUtil.addGroup();
 	}
 
 	@Override
 	protected DLFolder addBaseModel(long userId) throws Exception {
-		DLFolder dlFolder = DLFolderUADTestUtil.addDLFolder(
-			_dlAppLocalService, _dlFolderLocalService, userId);
-
-		_dlFolders.add(dlFolder);
-
-		return dlFolder;
+		return DLFolderUADTestUtil.addDLFolder(
+			_dlAppLocalService, _dlFolderLocalService, userId,
+			_group.getGroupId());
 	}
 
 	@Override
@@ -87,7 +89,7 @@ public class DLFolderUADExporterTest
 	private DLFolderLocalService _dlFolderLocalService;
 
 	@DeleteAfterTestRun
-	private final List<DLFolder> _dlFolders = new ArrayList<>();
+	private Group _group;
 
 	@Inject(filter = "component.name=*.DLFolderUADExporter")
 	private UADExporter _uadExporter;

--- a/modules/apps/document-library/document-library-uad-test/src/testIntegration/java/com/liferay/document/library/uad/test/DLFileEntryTypeUADTestUtil.java
+++ b/modules/apps/document-library/document-library-uad-test/src/testIntegration/java/com/liferay/document/library/uad/test/DLFileEntryTypeUADTestUtil.java
@@ -42,7 +42,7 @@ public class DLFileEntryTypeUADTestUtil {
 
 	public static DLFileEntryType addDLFileEntryType(
 			DLFileEntryTypeLocalService dlFileEntryTypeLocalService,
-			Portal portal, long userId)
+			Portal portal, long userId, long groupId)
 		throws Exception {
 
 		ServiceContext serviceContext =
@@ -69,13 +69,13 @@ public class DLFileEntryTypeUADTestUtil {
 			"com.liferay.dynamic.data.lists.model.DDLRecordSet");
 
 		DDMStructure ddmStructure = DDMStructureManagerUtil.addStructure(
-			TestPropsValues.getUserId(), TestPropsValues.getGroupId(), null,
-			classNameId, RandomTestUtil.randomString(), nameMap, descriptionMap,
-			ddmForm, StorageEngineManager.STORAGE_TYPE_DEFAULT,
+			TestPropsValues.getUserId(), groupId, null, classNameId,
+			RandomTestUtil.randomString(), nameMap, descriptionMap, ddmForm,
+			StorageEngineManager.STORAGE_TYPE_DEFAULT,
 			DDMStructureManager.STRUCTURE_TYPE_DEFAULT, serviceContext);
 
 		return dlFileEntryTypeLocalService.addFileEntryType(
-			userId, TestPropsValues.getGroupId(), RandomTestUtil.randomString(),
+			userId, groupId, RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(),
 			new long[] {ddmStructure.getStructureId()}, serviceContext);
 	}

--- a/modules/apps/document-library/document-library-uad-test/src/testIntegration/java/com/liferay/document/library/uad/test/DLFileEntryUADTestUtil.java
+++ b/modules/apps/document-library/document-library-uad-test/src/testIntegration/java/com/liferay/document/library/uad/test/DLFileEntryUADTestUtil.java
@@ -26,7 +26,6 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestDataConstants;
-import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ContentTypes;
 
 import java.io.ByteArrayInputStream;
@@ -42,24 +41,24 @@ public class DLFileEntryUADTestUtil {
 	public static DLFileEntry addDLFileEntry(
 			DLAppLocalService dlAppLocalService,
 			DLFileEntryLocalService dlFileEntryLocalService,
-			DLFolderLocalService dlFolderLocalService, long userId)
+			DLFolderLocalService dlFolderLocalService, long userId,
+			long groupId)
 		throws Exception {
 
 		DLFolder dlFolder = dlFolderLocalService.addFolder(
-			userId, TestPropsValues.getGroupId(), TestPropsValues.getGroupId(),
-			false, 0L, RandomTestUtil.randomString(),
+			userId, groupId, groupId, false, 0L, RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(), false,
 			ServiceContextTestUtil.getServiceContext());
 
 		return addDLFileEntry(
 			dlAppLocalService, dlFileEntryLocalService, dlFolder.getFolderId(),
-			userId);
+			userId, groupId);
 	}
 
 	public static DLFileEntry addDLFileEntry(
 			DLAppLocalService dlAppLocalService,
 			DLFileEntryLocalService dlFileEntryLocalService, long dlFolderId,
-			long userId)
+			long userId, long groupId)
 		throws Exception {
 
 		ServiceContext serviceContext =
@@ -70,10 +69,10 @@ public class DLFileEntryUADTestUtil {
 		InputStream is = new ByteArrayInputStream(bytes);
 
 		FileEntry fileEntry = dlAppLocalService.addFileEntry(
-			userId, TestPropsValues.getGroupId(), dlFolderId,
-			RandomTestUtil.randomString(), ContentTypes.TEXT_PLAIN,
-			RandomTestUtil.randomString(), StringPool.BLANK, StringPool.BLANK,
-			is, bytes.length, serviceContext);
+			userId, groupId, dlFolderId, RandomTestUtil.randomString(),
+			ContentTypes.TEXT_PLAIN, RandomTestUtil.randomString(),
+			StringPool.BLANK, StringPool.BLANK, is, bytes.length,
+			serviceContext);
 
 		return dlFileEntryLocalService.getFileEntry(fileEntry.getFileEntryId());
 	}

--- a/modules/apps/document-library/document-library-uad-test/src/testIntegration/java/com/liferay/document/library/uad/test/DLFileShortcutUADTestUtil.java
+++ b/modules/apps/document-library/document-library-uad-test/src/testIntegration/java/com/liferay/document/library/uad/test/DLFileShortcutUADTestUtil.java
@@ -26,7 +26,6 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestDataConstants;
-import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
@@ -43,15 +42,15 @@ public class DLFileShortcutUADTestUtil {
 	public static DLFileShortcut addDLFileShortcut(
 			DLFileEntryLocalService dlFileEntryLocalService,
 			DLFileShortcutLocalService dlFileShortcutLocalService,
-			DLFolderLocalService dlFolderLocalService, long userId)
+			DLFolderLocalService dlFolderLocalService, long userId,
+			long groupId)
 		throws Exception {
 
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext();
 
 		DLFolder dlFolder = dlFolderLocalService.addFolder(
-			userId, TestPropsValues.getGroupId(), TestPropsValues.getGroupId(),
-			false, 0L, RandomTestUtil.randomString(),
+			userId, groupId, groupId, false, 0L, RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(), false, serviceContext);
 
 		byte[] bytes = TestDataConstants.TEST_BYTE_ARRAY;
@@ -67,21 +66,20 @@ public class DLFileShortcutUADTestUtil {
 			null, is, bytes.length, serviceContext);
 
 		return dlFileShortcutLocalService.addFileShortcut(
-			userId, TestPropsValues.getGroupId(), TestPropsValues.getGroupId(),
-			dlFolder.getFolderId(), dlFileEntry.getFileEntryId(),
-			serviceContext);
+			userId, groupId, groupId, dlFolder.getFolderId(),
+			dlFileEntry.getFileEntryId(), serviceContext);
 	}
 
 	public static DLFileShortcut addDLFileShortcutWithStatusByUserId(
 			DLFileEntryLocalService dlFileEntryLocalService,
 			DLFileShortcutLocalService dlFileShortcutLocalService,
 			DLFolderLocalService dlFolderLocalService, long userId,
-			long statusByUserId)
+			long groupId, long statusByUserId)
 		throws Exception {
 
 		DLFileShortcut dlFileShortcut = addDLFileShortcut(
 			dlFileEntryLocalService, dlFileShortcutLocalService,
-			dlFolderLocalService, userId);
+			dlFolderLocalService, userId, groupId);
 
 		return dlFileShortcutLocalService.updateStatus(
 			statusByUserId, dlFileShortcut.getFileShortcutId(),

--- a/modules/apps/document-library/document-library-uad-test/src/testIntegration/java/com/liferay/document/library/uad/test/DLFolderUADTestUtil.java
+++ b/modules/apps/document-library/document-library-uad-test/src/testIntegration/java/com/liferay/document/library/uad/test/DLFolderUADTestUtil.java
@@ -20,7 +20,6 @@ import com.liferay.document.library.kernel.service.DLFolderLocalService;
 import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
-import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
 import java.util.List;
@@ -32,21 +31,23 @@ public class DLFolderUADTestUtil {
 
 	public static DLFolder addDLFolder(
 			DLAppLocalService dlAppLocalService,
-			DLFolderLocalService dlFolderLocalService, long userId)
+			DLFolderLocalService dlFolderLocalService, long userId,
+			long groupId)
 		throws Exception {
 
-		return addDLFolder(dlAppLocalService, dlFolderLocalService, userId, 0L);
+		return addDLFolder(
+			dlAppLocalService, dlFolderLocalService, userId, groupId, 0L);
 	}
 
 	public static DLFolder addDLFolder(
 			DLAppLocalService dlAppLocalService,
 			DLFolderLocalService dlFolderLocalService, long userId,
-			long parentFolderId)
+			long groupId, long parentFolderId)
 		throws Exception {
 
 		Folder folder = dlAppLocalService.addFolder(
-			userId, TestPropsValues.getGroupId(), parentFolderId,
-			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			userId, groupId, parentFolderId, RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(),
 			ServiceContextTestUtil.getServiceContext());
 
 		return (DLFolder)folder.getModel();
@@ -55,11 +56,11 @@ public class DLFolderUADTestUtil {
 	public static DLFolder addDLFolderWithStatusByUserId(
 			DLAppLocalService dlAppLocalService,
 			DLFolderLocalService dlFolderLocalService, long userId,
-			long statusByUserId)
+			long groupId, long statusByUserId)
 		throws Exception {
 
 		DLFolder dlFolder = addDLFolder(
-			dlAppLocalService, dlFolderLocalService, userId);
+			dlAppLocalService, dlFolderLocalService, userId, groupId);
 
 		return dlFolderLocalService.updateStatus(
 			statusByUserId, dlFolder.getFolderId(),

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
@@ -372,10 +372,6 @@ public class FriendlyURLServlet extends HttpServlet {
 			redirect = new Redirect();
 		}
 
-		if (_log.isDebugEnabled()) {
-			_log.debug("Redirect " + redirect.getPath());
-		}
-
 		if (redirect.isValidForward()) {
 			ServletContext servletContext = getServletContext();
 
@@ -394,17 +390,44 @@ public class FriendlyURLServlet extends HttpServlet {
 			}
 
 			if (requestDispatcher != null) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(
+						StringBundler.concat(
+							"Forward from ",
+							httpServletRequest.getRequestURI(),
+							" to ",
+							redirect.getPath()));
+				}
+
 				requestDispatcher.forward(
 					httpServletRequest, httpServletResponse);
 			}
 		}
 		else {
 			if (redirect.isPermanent()) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(
+						StringBundler.concat(
+							"Location Moved Permanently from ",
+							httpServletRequest.getRequestURI(),
+							" to ",
+							redirect.getPath()));
+				}
+
 				httpServletResponse.setHeader("Location", redirect.getPath());
 				httpServletResponse.setStatus(
 					HttpServletResponse.SC_MOVED_PERMANENTLY);
 			}
 			else {
+				if (_log.isDebugEnabled()) {
+					_log.debug(
+						StringBundler.concat(
+							"Redirect from ",
+							httpServletRequest.getRequestURI(),
+							" to ",
+							redirect.getPath()));
+				}
+
 				httpServletResponse.sendRedirect(redirect.getPath());
 			}
 		}

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
@@ -408,7 +408,7 @@ public class FriendlyURLServlet extends HttpServlet {
 				if (_log.isDebugEnabled()) {
 					_log.debug(
 						StringBundler.concat(
-							"Location Moved Permanently from ",
+							"Location moved permanently from ",
 							httpServletRequest.getRequestURI(),
 							" to ",
 							redirect.getPath()));

--- a/modules/test/jenkins-results-parser/bnd.bnd
+++ b/modules/test/jenkins-results-parser/bnd.bnd
@@ -1,3 +1,3 @@
 Bundle-Name: Liferay Jenkins Results Parser
 Bundle-SymbolicName: com.liferay.jenkins.results.parser
-Bundle-Version: 1.0.511
+Bundle-Version: 1.0.512

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/FilePropagator.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/FilePropagator.java
@@ -31,6 +31,13 @@ public class FilePropagator {
 		String[] fileNames, String sourceDirName, String targetDirName,
 		List<String> targetSlaves) {
 
+		this(fileNames, sourceDirName, targetDirName, null, targetSlaves);
+	}
+
+	public FilePropagator(
+		String[] fileNames, String sourceDirName, String targetDirName,
+		String primaryTargetSlave, List<String> targetSlaves) {
+
 		for (String fileName : fileNames) {
 			_filePropagatorTasks.add(
 				new FilePropagatorTask(
@@ -39,6 +46,7 @@ public class FilePropagator {
 		}
 
 		_targetSlaves.addAll(targetSlaves);
+		_primaryTargetSlave = primaryTargetSlave;
 	}
 
 	public long getAverageThreadDuration() {
@@ -130,11 +138,7 @@ public class FilePropagator {
 
 		List<String> commands = new ArrayList<>();
 
-		String targetSlave = null;
-
 		for (FilePropagatorTask filePropagatorTask : _filePropagatorTasks) {
-			targetSlave = _targetSlaves.get(0);
-
 			String sourceFileName = filePropagatorTask._sourceFileName;
 
 			System.out.println("Copying from source " + sourceFileName);
@@ -156,6 +160,17 @@ public class FilePropagator {
 				0, targetFileName.lastIndexOf("/"));
 
 			commands.add("ls -al " + targetDirName);
+		}
+
+		String targetSlave;
+
+		if (_primaryTargetSlave != null) {
+			targetSlave = _primaryTargetSlave;
+
+			_primaryTargetSlave = null;
+		}
+		else {
+			targetSlave = _targetSlaves.get(0);
 		}
 
 		try {
@@ -224,6 +239,7 @@ public class FilePropagator {
 	private final List<FilePropagatorTask> _filePropagatorTasks =
 		new ArrayList<>();
 	private final List<String> _mirrorSlaves = new ArrayList<>();
+	private String _primaryTargetSlave;
 	private final List<String> _targetSlaves = new ArrayList<>();
 	private int _threadsCompletedCount;
 	private long _threadsDurationTotal;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/FilePropagator.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/FilePropagator.java
@@ -45,8 +45,13 @@ public class FilePropagator {
 					targetDirName + "/" + fileName));
 		}
 
+		if (primaryTargetSlave != null) {
+			targetSlaves.remove(primaryTargetSlave);
+
+			_targetSlaves.add(primaryTargetSlave);
+		}
+
 		_targetSlaves.addAll(targetSlaves);
-		_primaryTargetSlave = primaryTargetSlave;
 	}
 
 	public long getAverageThreadDuration() {
@@ -162,36 +167,21 @@ public class FilePropagator {
 			commands.add("ls -al " + targetDirName);
 		}
 
-		String targetSlave;
-
-		if (_primaryTargetSlave != null) {
-			targetSlave = _primaryTargetSlave;
-
-			_primaryTargetSlave = null;
-		}
-		else {
-			targetSlave = _targetSlaves.get(0);
-		}
+		String targetSlave = _targetSlaves.remove(0);
 
 		try {
 			if (_executeBashCommands(commands, targetSlave) != 0) {
 				_errorSlaves.add(targetSlave);
-				_targetSlaves.remove(targetSlave);
 
 				_copyFromSource();
-
-				targetSlave = null;
+			}
+			else {
+				_mirrorSlaves.add(targetSlave);
 			}
 		}
 		catch (Exception e) {
 			throw new RuntimeException(
 				"Unable to copy from source. Executed: " + commands, e);
-		}
-
-		if (targetSlave != null) {
-			_mirrorSlaves.add(targetSlave);
-
-			_targetSlaves.remove(targetSlave);
 		}
 
 		System.out.println("Finished copying from source.");
@@ -239,7 +229,6 @@ public class FilePropagator {
 	private final List<FilePropagatorTask> _filePropagatorTasks =
 		new ArrayList<>();
 	private final List<String> _mirrorSlaves = new ArrayList<>();
-	private String _primaryTargetSlave;
 	private final List<String> _targetSlaves = new ArrayList<>();
 	private int _threadsCompletedCount;
 	private long _threadsDurationTotal;

--- a/portal-impl/src/com/liferay/portal/workflow/permission/WorkflowPermissionImpl.java
+++ b/portal-impl/src/com/liferay/portal/workflow/permission/WorkflowPermissionImpl.java
@@ -54,9 +54,7 @@ public class WorkflowPermissionImpl implements WorkflowPermission {
 
 		long companyId = permissionChecker.getCompanyId();
 
-		if (permissionChecker.isCompanyAdmin() ||
-			permissionChecker.isGroupAdmin(groupId)) {
-
+		if (permissionChecker.isContentReviewer(companyId, groupId)) {
 			return Boolean.TRUE;
 		}
 


### PR DESCRIPTION
Hi @inacionery ,

Can you review this pull request, please?

You have further information in LPS-99515 about how to reproduce the issue. About the analysis, in a nutshell, [this check](https://github.com/liferay/liferay-portal/blob/master/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/security/permission/resource/DLFileEntryModelResourcePermissionRegistrar.java#L220-L222) was returning null for Content Reviewers, but users which such role should be able to see documents they need to approve/reject.

The change is keeping the permissions for companyAdmin and groupAdmin and extending them to Content Reviewers as you can see [here](https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java#L844).

Feel free to ask me any doubt about this case.

Thanks.

Regards.