### PR TITLE
LPS-98280 | Apply new Portlet URL utilities in calendar-web

### DIFF
--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/edit_calendar_booking.jsp
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/edit_calendar_booking.jsp
@@ -245,6 +245,8 @@ while (manageableCalendarsIterator.hasNext()) {
 		function() {
 			var remoteServices = new Liferay.CalendarRemoteServices(
 				{
+					baseActionURL: '<%= PortletURLFactoryUtil.create(request, portletDisplay.getId(), PortletRequest.ACTION_PHASE) %>',
+					baseResourceURL: '<%= PortletURLFactoryUtil.create(request, portletDisplay.getId(), PortletRequest.RESOURCE_PHASE) %>',
 					invokerURL: themeDisplay.getPathContext() + '/api/jsonws/invoke',
 					namespace: '<portlet:namespace />'
 				}

--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/init.jsp
@@ -89,6 +89,7 @@ page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
 page import="com.liferay.portal.kernel.model.Group" %><%@
 page import="com.liferay.portal.kernel.model.User" %><%@
 page import="com.liferay.portal.kernel.portlet.LiferayWindowState" %><%@
+page import="com.liferay.portal.kernel.portlet.PortletURLFactoryUtil" %><%@
 page import="com.liferay.portal.kernel.security.permission.ActionKeys" %><%@
 page import="com.liferay.portal.kernel.security.permission.ResourceActionsUtil" %><%@
 page import="com.liferay.portal.kernel.service.ClassNameLocalServiceUtil" %><%@
@@ -131,7 +132,8 @@ page import="java.util.List" %><%@
 page import="java.util.Objects" %><%@
 page import="java.util.TimeZone" %>
 
-<%@ page import="javax.portlet.PortletURL" %>
+<%@ page import="javax.portlet.PortletRequest" %><%@
+page import="javax.portlet.PortletURL" %>
 
 <liferay-frontend:defineObjects />
 

--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/calendar_util.js
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/calendar_util.js
@@ -275,8 +275,7 @@ AUI.add(
 			'aui-scheduler',
 			'aui-toolbar',
 			'autocomplete',
-			'autocomplete-highlighters',
-			'liferay-portlet-url'
+			'autocomplete-highlighters'
 		]
 	}
 );

--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/config.js
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/config.js
@@ -81,8 +81,7 @@
 							'aui-base',
 							'aui-component',
 							'liferay-calendar-util',
-							'liferay-portlet-base',
-							'liferay-portlet-url'
+							'liferay-portlet-base'
 						]
 					},
 					'liferay-calendar-session-listener': {
@@ -116,8 +115,7 @@
 							'aui-scheduler',
 							'aui-toolbar',
 							'autocomplete',
-							'autocomplete-highlighters',
-							'liferay-portlet-url'
+							'autocomplete-highlighters'
 						]
 					},
 					'liferay-scheduler': {

--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/remote_services.js
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/remote_services.js
@@ -548,8 +548,7 @@ AUI.add(
 			'aui-component',
 			'liferay-calendar-message-util',
 			'liferay-calendar-util',
-			'liferay-portlet-base',
-			'liferay-portlet-url'
+			'liferay-portlet-base'
 		]
 	}
 );

--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/view_calendar.jsp
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/view_calendar.jsp
@@ -64,6 +64,8 @@ boolean columnOptionsVisible = GetterUtil.getBoolean(SessionClicks.get(request, 
 		function() {
 			var remoteServices = new Liferay.CalendarRemoteServices(
 				{
+					baseActionURL: '<%= PortletURLFactoryUtil.create(request, portletDisplay.getId(), PortletRequest.ACTION_PHASE) %>',
+					baseResourceURL: '<%= PortletURLFactoryUtil.create(request, portletDisplay.getId(), PortletRequest.RESOURCE_PHASE) %>',
 					invokerURL: themeDisplay.getPathContext() + '/api/jsonws/invoke',
 					namespace: '<portlet:namespace />',
 					userId: themeDisplay.getUserId()


### PR DESCRIPTION
Hi @jbalsas ,

This is continuation of https://github.com/julien/liferay-portal/pull/153 and https://github.com/jbalsas/liferay-portal/pull/1930.

In this PR, we are defining base URLs in backend, and forwarding it to frontend, where it is modified. This practice is common throughout portal. The current solution, that we are replacing, relies on old `Liferay.PortletURL` utility to set a default base URL, a value [hardcoded in utility](https://github.com/liferay/liferay-portal/blob/7f73d850931e4e52b9ca9ee05b44282644a1ec24/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/portlet_url.js#L57). The new `Liferay.Util.PortletURL` utility does not have that hardcoded value, instead requiring base value as an argument.

The alternative to solution in this PR would be to re-introduce hardcoded default url to util, but I believe it makes more sense to standardize usage in the app, to get it from backend. This app is the only or one of two places in portal using the default value.

Please review the code.

Thank you!

/cc @kresimir-coko @inacionery