### PR TITLE
LPS-100980 Calendar event as-you-type filtering of invitation suggestions doesn't work

### DIFF
--- a/modules/apps/calendar/calendar-web/src/main/java/com/liferay/calendar/web/internal/portlet/CalendarPortlet.java
+++ b/modules/apps/calendar/calendar-web/src/main/java/com/liferay/calendar/web/internal/portlet/CalendarPortlet.java
@@ -1219,8 +1219,13 @@ public class CalendarPortlet extends MVCPortlet {
 
 		keywords = StringUtil.toLowerCase(keywords);
 
-		searchContext.setAttribute(Field.NAME, keywords);
-		searchContext.setAttribute("resourceName", keywords);
+		String localizedName = LocalizationUtil.getLocalizedName(
+			Field.NAME, searchContext.getLanguageId());
+		String localizedResourceName = LocalizationUtil.getLocalizedName(
+			"resourceName", searchContext.getLanguageId());
+
+		searchContext.setAttribute(localizedName, keywords);
+		searchContext.setAttribute(localizedResourceName, keywords);
 
 		searchContext.setCompanyId(themeDisplay.getCompanyId());
 		searchContext.setEnd(SearchContainer.DEFAULT_DELTA);


### PR DESCRIPTION
Hi @inacionery 

Could you please review this pull request?
I added the localized field name to the searchContext because CalendarKeywordQueryContributor.contribute() also [adds only the localized terms](https://github.com/liferay/liferay-portal/blob/master/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/internal/search/spi/model/query/contributor/CalendarKeywordQueryContributor.java#L40).

Thank you and best regards,
István