### PR TITLE
LPS-102733 Change default date format to use pattern that displays 4 …

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/util/DateUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/DateUtil.java
@@ -66,7 +66,8 @@ public class DateUtil {
 
 		Date dateValue = parseDate(fromPattern, dateString, locale);
 
-		Format dateFormat = FastDateFormatFactoryUtil.getDate(locale);
+		Format dateFormat = FastDateFormatFactoryUtil.getSimpleDateFormat(
+			"M/dd/yyyy", locale);
 
 		return dateFormat.format(dateValue);
 	}


### PR DESCRIPTION
/cc @knchau

Notes from Kim:

> https://issues.liferay.com/browse/LPS-102733
> 
> The issue is the display of DDL date is not consistent. The data list stores the information with pattern `"yyyy"`, but on retrieve the API extracts the value with pattern `"yy"`. The solution is to use a different function that uses the specified date pattern intended to keep consistency.