### PR TITLE
[TECHNICAL SUPPORT] LPS-107117 My Workflow Tasks list cannot be sorted and ordered at the same time

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/internal/display/context/WorkflowTaskDisplayContext.java
+++ b/modules/apps/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/internal/display/context/WorkflowTaskDisplayContext.java
@@ -393,6 +393,7 @@ public class WorkflowTaskDisplayContext {
 
 		PortletURL portletURL = liferayPortletResponse.createRenderURL();
 
+		portletURL.setParameter("navigation", _getNavigation());
 		portletURL.setParameter("tabs1", _getTabs1());
 		portletURL.setParameter("orderByCol", _getOrderByCol());
 


### PR DESCRIPTION
Hey @inacionery ,

Please review my changes

Please note: It can be difficult to test due to:
https://issues.liferay.com/browse/LPS-107033
However if the disabled attribute is removed as per:
https://github.com/brianchandotcom/liferay-portal/pull/76515/files
It should be a joyride. Currently not sure why this change has been reverted, I think it's due to a UI test that has not been changed parallel to merging LPS-97871

Thanks,