### PR TITLE
[TS] LPS-111718

### DIFF
--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarBookingLocalServiceImpl.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarBookingLocalServiceImpl.java
@@ -843,7 +843,7 @@ public class CalendarBookingLocalServiceImpl
 			long calendarBookingId = calendarBooking.getCalendarBookingId();
 
 			long[] childCalendarIds = getChildCalendarIds(
-				calendarBooking.getCalendarBookingId(), calendarId);
+				calendarBookingId, calendarId);
 
 			long duration =
 				calendarBooking.getEndTime() - calendarBooking.getStartTime();
@@ -855,18 +855,11 @@ public class CalendarBookingLocalServiceImpl
 			AssetEntry assetEntry = _assetEntryLocalService.fetchEntry(
 				CalendarBooking.class.getName(), calendarBookingId);
 
-			List<AssetLink> assetLinks = _assetLinkLocalService.getLinks(
+			List<AssetLink> assetLinks = _assetLinkLocalService.getDirectLinks(
 				assetEntry.getEntryId());
 
 			long[] assetLinkEntryIds = ListUtil.toLongArray(
-				assetLinks,
-				assetLink -> {
-					if (assetLink.getEntryId1() == assetEntry.getEntryId()) {
-						return assetLink.getEntryId2();
-					}
-
-					return assetLink.getEntryId1();
-				});
+				assetLinks, AssetLink.ENTRY_ID2_ACCESSOR);
 
 			serviceContext.setAssetTagNames(assetEntry.getTagNames());
 			serviceContext.setAssetCategoryIds(assetEntry.getCategoryIds());

--- a/modules/apps/calendar/calendar-web/src/main/java/com/liferay/calendar/web/internal/portlet/CalendarPortlet.java
+++ b/modules/apps/calendar/calendar-web/src/main/java/com/liferay/calendar/web/internal/portlet/CalendarPortlet.java
@@ -19,8 +19,8 @@ import com.liferay.asset.kernel.exception.AssetTagException;
 import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.asset.kernel.model.AssetLink;
 import com.liferay.asset.kernel.model.AssetVocabulary;
-import com.liferay.asset.kernel.service.AssetEntryLocalServiceUtil;
-import com.liferay.asset.kernel.service.AssetLinkLocalServiceUtil;
+import com.liferay.asset.kernel.service.AssetEntryLocalService;
+import com.liferay.asset.kernel.service.AssetLinkLocalService;
 import com.liferay.calendar.constants.CalendarPortletKeys;
 import com.liferay.calendar.exception.CalendarBookingDurationException;
 import com.liferay.calendar.exception.CalendarBookingRecurrenceException;
@@ -640,10 +640,10 @@ public class CalendarPortlet extends MVCPortlet {
 		ServiceContext serviceContext = ServiceContextFactory.getInstance(
 			CalendarBooking.class.getName(), actionRequest);
 
-		AssetEntry assetEntry = AssetEntryLocalServiceUtil.fetchEntry(
+		AssetEntry assetEntry = _assetEntryLocalService.fetchEntry(
 			CalendarBooking.class.getName(), calendarBookingId);
 
-		List<AssetLink> assetLinks = AssetLinkLocalServiceUtil.getLinks(
+		List<AssetLink> assetLinks = _assetLinkLocalService.getLinks(
 			assetEntry.getEntryId());
 
 		long[] assetLinkEntryIds = ListUtil.toLongArray(
@@ -1812,6 +1812,12 @@ public class CalendarPortlet extends MVCPortlet {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		CalendarPortlet.class);
+
+	@Reference
+	private AssetEntryLocalService _assetEntryLocalService;
+
+	@Reference
+	private AssetLinkLocalService _assetLinkLocalService;
 
 	@Reference(
 		target = "(model.class.name=com.liferay.calendar.model.Calendar)"

--- a/modules/apps/calendar/calendar-web/src/main/java/com/liferay/calendar/web/internal/portlet/CalendarPortlet.java
+++ b/modules/apps/calendar/calendar-web/src/main/java/com/liferay/calendar/web/internal/portlet/CalendarPortlet.java
@@ -643,18 +643,11 @@ public class CalendarPortlet extends MVCPortlet {
 		AssetEntry assetEntry = _assetEntryLocalService.fetchEntry(
 			CalendarBooking.class.getName(), calendarBookingId);
 
-		List<AssetLink> assetLinks = _assetLinkLocalService.getLinks(
+		List<AssetLink> assetLinks = _assetLinkLocalService.getDirectLinks(
 			assetEntry.getEntryId());
 
 		long[] assetLinkEntryIds = ListUtil.toLongArray(
-			assetLinks,
-			assetLink -> {
-				if (assetLink.getEntryId1() == assetEntry.getEntryId()) {
-					return assetLink.getEntryId2();
-				}
-
-				return assetLink.getEntryId1();
-			});
+			assetLinks, AssetLink.ENTRY_ID2_ACCESSOR);
 
 		serviceContext.setAssetTagNames(assetEntry.getTagNames());
 		serviceContext.setAssetCategoryIds(assetEntry.getCategoryIds());


### PR DESCRIPTION
From @kevhlee:

> Ticket: https://issues.liferay.com/browse/LPS-111718
> 
> When the user updates a calendar booking, a new booking is created with the update and the old one is deleted, as seen [here](https://github.com/kevhlee/liferay-portal/blob/LPS-111718/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarBookingLocalServiceImpl.java#L1386-L1458). The issue is that, when updates are made using the "Save" button or when the RSVP value is changed, the assets of the old booking are not stored in the service context and therefore not passed to the new booking. The service context is used to update the asset fields of calendar bookings, as seen [here](https://github.com/kevhlee/liferay-portal/blob/LPS-111718/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarBookingLocalServiceImpl.java#L267-L271).
> 
> To fix this issue, I made sure that the assets of the old booking are stored in the service context before the booking is updated. For finding the asset link entry IDs, I followed the logic found in [AssetLinksTag.java](https://github.com/kevhlee/liferay-portal/blob/LPS-111718/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/servlet/taglib/AssetLinksTag.java#L206-L213). I do not use `AssetLink.ENTRY_ID2_ACCESSOR` as it can lead to strange results, such as having a calendar booking reference itself under the `Related Assets` section.


From @wanderlast:

> The explanation I wrote to Kevin for the changes I made:

> The primary change I've made is to your assetLinkEntryIds logic. I've switched the call to _assetLinkLocalService.getLinks() to _assetLinkLocalService.getDirectLinks(). If you look at the API for these two methods, you'll notice that getLinks() returns all entries that have the entryId in either the entryId1 or entryId2 columns. However, this is a problem, since if you look at the AssetLink table you'll notice that when we add a related asset to the event, two records are created per link with the major difference only being the switching of entryId1 with entryId2. Using getDirectLinks() we guarantee that we are only getting assetLinks where entryId == entryId1, which automatically means that we only need the entryId2s when retrieving the assetLinkEntryIds.
> 
> I also made one SF change with calendarBookingId to add it to the next method call since you have changed it so that we save the value to a variable already.