### PR TITLE
[TS] LPS-111718

### DIFF
--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarBookingLocalServiceImpl.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarBookingLocalServiceImpl.java
@@ -843,7 +843,7 @@ public class CalendarBookingLocalServiceImpl
 			long calendarBookingId = calendarBooking.getCalendarBookingId();
 
 			long[] childCalendarIds = getChildCalendarIds(
-				calendarBooking.getCalendarBookingId(), calendarId);
+				calendarBookingId, calendarId);
 
 			long duration =
 				calendarBooking.getEndTime() - calendarBooking.getStartTime();
@@ -855,18 +855,11 @@ public class CalendarBookingLocalServiceImpl
 			AssetEntry assetEntry = _assetEntryLocalService.fetchEntry(
 				CalendarBooking.class.getName(), calendarBookingId);
 
-			List<AssetLink> assetLinks = _assetLinkLocalService.getLinks(
+			List<AssetLink> assetLinks = _assetLinkLocalService.getDirectLinks(
 				assetEntry.getEntryId());
 
 			long[] assetLinkEntryIds = ListUtil.toLongArray(
-				assetLinks,
-				assetLink -> {
-					if (assetLink.getEntryId1() == assetEntry.getEntryId()) {
-						return assetLink.getEntryId2();
-					}
-
-					return assetLink.getEntryId1();
-				});
+				assetLinks, AssetLink.ENTRY_ID2_ACCESSOR);
 
 			serviceContext.setAssetTagNames(assetEntry.getTagNames());
 			serviceContext.setAssetCategoryIds(assetEntry.getCategoryIds());

--- a/modules/apps/calendar/calendar-web/src/main/java/com/liferay/calendar/web/internal/portlet/CalendarPortlet.java
+++ b/modules/apps/calendar/calendar-web/src/main/java/com/liferay/calendar/web/internal/portlet/CalendarPortlet.java
@@ -616,6 +616,9 @@ public class CalendarPortlet extends MVCPortlet {
 		boolean allFollowing = ParamUtil.getBoolean(
 			actionRequest, "allFollowing");
 
+		ServiceContext serviceContext = ServiceContextFactory.getInstance(
+			CalendarBooking.class.getName(), actionRequest);
+
 		if (calendarBooking != null) {
 			childCalendarIds = _calendarBookingLocalService.getChildCalendarIds(
 				calendarBookingId, calendarId);
@@ -630,16 +633,13 @@ public class CalendarPortlet extends MVCPortlet {
 				calendarBooking.getFirstReminderType(),
 				calendarBooking.getSecondReminderType()
 			};
+
+			addAssetEntry(calendarBooking, serviceContext);
 		}
 
 		String title = ParamUtil.getString(actionRequest, "title");
 
 		titleMap.put(LocaleUtil.getSiteDefault(), title);
-
-		ServiceContext serviceContext = ServiceContextFactory.getInstance(
-			CalendarBooking.class.getName(), actionRequest);
-
-		addAssetEntry(calendarBooking, serviceContext);
 
 		JSONObject jsonObject = null;
 

--- a/modules/apps/calendar/calendar-web/src/main/java/com/liferay/calendar/web/internal/portlet/CalendarPortlet.java
+++ b/modules/apps/calendar/calendar-web/src/main/java/com/liferay/calendar/web/internal/portlet/CalendarPortlet.java
@@ -19,8 +19,8 @@ import com.liferay.asset.kernel.exception.AssetTagException;
 import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.asset.kernel.model.AssetLink;
 import com.liferay.asset.kernel.model.AssetVocabulary;
-import com.liferay.asset.kernel.service.AssetEntryLocalServiceUtil;
-import com.liferay.asset.kernel.service.AssetLinkLocalServiceUtil;
+import com.liferay.asset.kernel.service.AssetEntryLocalService;
+import com.liferay.asset.kernel.service.AssetLinkLocalService;
 import com.liferay.calendar.constants.CalendarPortletKeys;
 import com.liferay.calendar.exception.CalendarBookingDurationException;
 import com.liferay.calendar.exception.CalendarBookingRecurrenceException;
@@ -640,10 +640,10 @@ public class CalendarPortlet extends MVCPortlet {
 		ServiceContext serviceContext = ServiceContextFactory.getInstance(
 			CalendarBooking.class.getName(), actionRequest);
 
-		AssetEntry assetEntry = AssetEntryLocalServiceUtil.fetchEntry(
+		AssetEntry assetEntry = _assetEntryLocalService.fetchEntry(
 			CalendarBooking.class.getName(), calendarBookingId);
 
-		List<AssetLink> assetLinks = AssetLinkLocalServiceUtil.getLinks(
+		List<AssetLink> assetLinks = _assetLinkLocalService.getLinks(
 			assetEntry.getEntryId());
 
 		long[] assetLinkEntryIds = ListUtil.toLongArray(
@@ -1812,6 +1812,12 @@ public class CalendarPortlet extends MVCPortlet {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		CalendarPortlet.class);
+
+	@Reference
+	private AssetEntryLocalService _assetEntryLocalService;
+
+	@Reference
+	private AssetLinkLocalService _assetLinkLocalService;
 
 	@Reference(
 		target = "(model.class.name=com.liferay.calendar.model.Calendar)"

--- a/modules/apps/calendar/calendar-web/src/main/java/com/liferay/calendar/web/internal/portlet/CalendarPortlet.java
+++ b/modules/apps/calendar/calendar-web/src/main/java/com/liferay/calendar/web/internal/portlet/CalendarPortlet.java
@@ -127,7 +127,6 @@ import com.liferay.rss.util.RSSUtil;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.Serializable;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -640,26 +639,7 @@ public class CalendarPortlet extends MVCPortlet {
 		ServiceContext serviceContext = ServiceContextFactory.getInstance(
 			CalendarBooking.class.getName(), actionRequest);
 
-		AssetEntry assetEntry = _assetEntryLocalService.fetchEntry(
-			CalendarBooking.class.getName(), calendarBookingId);
-
-		List<AssetLink> assetLinks = _assetLinkLocalService.getDirectLinks(
-			assetEntry.getEntryId());
-
-		long[] assetLinkEntryIds = ListUtil.toLongArray(
-			assetLinks, AssetLink.ENTRY_ID2_ACCESSOR);
-
-		serviceContext.setAssetTagNames(assetEntry.getTagNames());
-		serviceContext.setAssetCategoryIds(assetEntry.getCategoryIds());
-		serviceContext.setAssetLinkEntryIds(assetLinkEntryIds);
-		serviceContext.setAssetPriority(assetEntry.getPriority());
-
-		ExpandoBridge expandoBridge = calendarBooking.getExpandoBridge();
-
-		Map<String, Serializable> expandoBridgeAttributes =
-			expandoBridge.getAttributes();
-
-		serviceContext.setExpandoBridgeAttributes(expandoBridgeAttributes);
+		addAssetEntry(calendarBooking, serviceContext);
 
 		JSONObject jsonObject = null;
 
@@ -692,6 +672,32 @@ public class CalendarPortlet extends MVCPortlet {
 		hideDefaultSuccessMessage(actionRequest);
 
 		writeJSON(actionRequest, actionResponse, jsonObject);
+	}
+
+	protected void addAssetEntry(
+		CalendarBooking calendarBooking, ServiceContext serviceContext) {
+
+		AssetEntry assetEntry = _assetEntryLocalService.fetchEntry(
+			CalendarBooking.class.getName(),
+			calendarBooking.getCalendarBookingId());
+
+		if (assetEntry != null) {
+			serviceContext.setAssetCategoryIds(assetEntry.getCategoryIds());
+			serviceContext.setAssetLinkEntryIds(
+				ListUtil.toLongArray(
+					_assetLinkLocalService.getDirectLinks(
+						assetEntry.getEntryId()),
+					AssetLink.ENTRY_ID2_ACCESSOR));
+			serviceContext.setAssetPriority(assetEntry.getPriority());
+			serviceContext.setAssetTagNames(assetEntry.getTagNames());
+		}
+
+		ExpandoBridge expandoBridge = calendarBooking.getExpandoBridge();
+
+		if (expandoBridge != null) {
+			serviceContext.setExpandoBridgeAttributes(
+				expandoBridge.getAttributes());
+		}
 	}
 
 	protected void addCalendar(

--- a/modules/apps/calendar/calendar-web/src/main/java/com/liferay/calendar/web/internal/portlet/CalendarPortlet.java
+++ b/modules/apps/calendar/calendar-web/src/main/java/com/liferay/calendar/web/internal/portlet/CalendarPortlet.java
@@ -643,18 +643,11 @@ public class CalendarPortlet extends MVCPortlet {
 		AssetEntry assetEntry = _assetEntryLocalService.fetchEntry(
 			CalendarBooking.class.getName(), calendarBookingId);
 
-		List<AssetLink> assetLinks = _assetLinkLocalService.getLinks(
+		List<AssetLink> assetLinks = _assetLinkLocalService.getDirectLinks(
 			assetEntry.getEntryId());
 
 		long[] assetLinkEntryIds = ListUtil.toLongArray(
-			assetLinks,
-			assetLink -> {
-				if (assetLink.getEntryId1() == assetEntry.getEntryId()) {
-					return assetLink.getEntryId2();
-				}
-
-				return assetLink.getEntryId1();
-			});
+			assetLinks, AssetLink.ENTRY_ID2_ACCESSOR);
 
 		serviceContext.setAssetTagNames(assetEntry.getTagNames());
 		serviceContext.setAssetCategoryIds(assetEntry.getCategoryIds());


### PR DESCRIPTION
From @kevhlee:

> Ticket: https://issues.liferay.com/browse/LPS-111718
> 
> When the user updates a calendar booking, a new booking is created with the update and the old one is deleted, as seen [here](https://github.com/kevhlee/liferay-portal/blob/LPS-111718/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarBookingLocalServiceImpl.java#L1386-L1458). The issue is that, when updates are made using the "Save" button or when the RSVP value is changed, the assets of the old booking are not stored in the service context and therefore not passed to the new booking. The service context is used to update the asset fields of calendar bookings, as seen [here](https://github.com/kevhlee/liferay-portal/blob/LPS-111718/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarBookingLocalServiceImpl.java#L267-L271). To fix this issue, I made sure that the assets of the old booking are stored in the service context before the booking is updated.
> 
> With regards,
> Kevin

CC @wanderlast

Resent from https://github.com/inacionery/liferay-portal/pull/588