### PR TITLE
[TS] LPS-112589

### DIFF
--- a/modules/apps/calendar/calendar-web/src/main/java/com/liferay/calendar/web/internal/portlet/CalendarPortlet.java
+++ b/modules/apps/calendar/calendar-web/src/main/java/com/liferay/calendar/web/internal/portlet/CalendarPortlet.java
@@ -1750,6 +1750,8 @@ public class CalendarPortlet extends MVCPortlet {
 						calendarBookingId, instanceIndex,
 						calendar.getCalendarId(), childCalendarIds, titleMap,
 						descriptionMap, location, startTime, endTime, allDay,
+						(recurrence == null) ? null :
+							RecurrenceSerializer.serialize(recurrence),
 						allFollowing, reminders[0], remindersType[0],
 						reminders[1], remindersType[1], serviceContext);
 			}


### PR DESCRIPTION
From @jesseyeh-liferay:

> [LPS-112589](https://issues.liferay.com/browse/LPS-112589) accounts for changes made to recurrence properties when updating a calendar event. When applying recurrence changes using the Following Events option, logic branches off [here](https://github.com/jesseyeh-liferay/liferay-portal/blob/bd4967c54565f3ed98cef62dc9e862747e1aaa03/modules/apps/calendar/calendar-web/src/main/java/com/liferay/calendar/web/internal/portlet/CalendarPortlet.java#L1714), whereas the Entire Series option branches off [here](https://github.com/jesseyeh-liferay/liferay-portal/blob/bd4967c54565f3ed98cef62dc9e862747e1aaa03/modules/apps/calendar/calendar-web/src/main/java/com/liferay/calendar/web/internal/portlet/CalendarPortlet.java#L1725) instead. Prior to LPS-112589, logic would incorrectly proceed using old recurrence properties.

CC @wanderlast