### PR TITLE
LPS-105652 Semver

### DIFF
--- a/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/workflow/DepotWorkflowHandlerController.java
+++ b/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/workflow/DepotWorkflowHandlerController.java
@@ -1,0 +1,174 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.depot.web.internal.workflow;
+
+import com.liferay.depot.web.internal.application.controller.DepotApplicationController;
+import com.liferay.osgi.util.ServiceTrackerFactory;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapDictionary;
+import com.liferay.portal.kernel.workflow.WorkflowHandler;
+
+import java.util.Dictionary;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.Constants;
+import org.osgi.framework.ServiceReference;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.util.tracker.ServiceTracker;
+import org.osgi.util.tracker.ServiceTrackerCustomizer;
+
+/**
+ * @author Adolfo Pérez
+ */
+@Component(immediate = true, service = DepotWorkflowHandlerController.class)
+public class DepotWorkflowHandlerController {
+
+	@Activate
+	protected void activate(BundleContext bundleContext) {
+		_serviceTracker = ServiceTrackerFactory.open(
+			bundleContext,
+			"(&(objectClass=com.liferay.portal.kernel.workflow." +
+				"WorkflowHandler)(!(depot.workflow.handler.wrapper=*)))",
+			new DepotWorkflowHandlerServiceTrackerCustomizer(bundleContext));
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		_serviceTracker.close();
+	}
+
+	@Reference
+	private DepotApplicationController _depotApplicationController;
+
+	private ServiceTracker<WorkflowHandler<?>, ServiceRegistration<?>>
+		_serviceTracker;
+
+	private final class DepotWorkflowHandlerServiceTrackerCustomizer
+		implements ServiceTrackerCustomizer
+			<WorkflowHandler<?>, ServiceRegistration<?>> {
+
+		public DepotWorkflowHandlerServiceTrackerCustomizer(
+			BundleContext bundleContext) {
+
+			_bundleContext = bundleContext;
+		}
+
+		@Override
+		public ServiceRegistration<?> addingService(
+			ServiceReference<WorkflowHandler<?>> serviceReference) {
+
+			WorkflowHandler<?> workflowHandler = _bundleContext.getService(
+				serviceReference);
+
+			Dictionary<String, Object> properties = new HashMapDictionary<>();
+
+			for (String key : serviceReference.getPropertyKeys()) {
+				if (!key.equals(Constants.SERVICE_RANKING)) {
+					properties.put(key, serviceReference.getProperty(key));
+				}
+			}
+
+			properties.put(
+				Constants.SERVICE_RANKING,
+				GetterUtil.getInteger(
+					serviceReference.getProperty(Constants.SERVICE_RANKING)) +
+						1);
+
+			properties.put("depot.workflow.handler.wrapper", Boolean.TRUE);
+
+			return _bundleContext.registerService(
+				WorkflowHandler.class,
+				new DepotWorkflowHandlerWrapper<>(
+					serviceReference, workflowHandler),
+				properties);
+		}
+
+		@Override
+		public void modifiedService(
+			ServiceReference<WorkflowHandler<?>> serviceReference,
+			ServiceRegistration<?> serviceRegistration) {
+
+			removedService(serviceReference, serviceRegistration);
+
+			addingService(serviceReference);
+		}
+
+		@Override
+		public void removedService(
+			ServiceReference<WorkflowHandler<?>> serviceReference,
+			ServiceRegistration<?> serviceRegistration) {
+
+			WorkflowHandler<?> workflowHandler = _bundleContext.getService(
+				serviceReference);
+
+			try {
+				if (workflowHandler instanceof DepotWorkflowHandlerWrapper) {
+					DepotWorkflowHandlerWrapper<?> depotWorkflowHandlerWrapper =
+						(DepotWorkflowHandlerWrapper<?>)workflowHandler;
+
+					_bundleContext.ungetService(
+						depotWorkflowHandlerWrapper.getServiceReference());
+				}
+			}
+			finally {
+				_bundleContext.ungetService(serviceReference);
+			}
+
+			serviceRegistration.unregister();
+		}
+
+		private final BundleContext _bundleContext;
+
+	}
+
+	private final class DepotWorkflowHandlerWrapper<T>
+		extends WorkflowHandlerWrapper<T> {
+
+		public DepotWorkflowHandlerWrapper(
+			ServiceReference<?> serviceReference,
+			WorkflowHandler<T> workflowHandler) {
+
+			super(workflowHandler);
+
+			_serviceReference = serviceReference;
+		}
+
+		public ServiceReference<?> getServiceReference() {
+			return _serviceReference;
+		}
+
+		@Override
+		public boolean isVisible(Group group) {
+			if ((group.getType() != GroupConstants.TYPE_DEPOT) ||
+				_depotApplicationController.isClassNameEnabled(
+					getClassName(), group.getGroupId())) {
+
+				return super.isVisible(group);
+			}
+
+			return false;
+		}
+
+		private final ServiceReference<?> _serviceReference;
+
+	}
+
+}

--- a/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/workflow/WorkflowHandlerWrapper.java
+++ b/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/workflow/WorkflowHandlerWrapper.java
@@ -1,0 +1,184 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.depot.web.internal.workflow;
+
+import com.liferay.asset.kernel.model.AssetRenderer;
+import com.liferay.asset.kernel.model.AssetRendererFactory;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.WorkflowDefinitionLink;
+import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
+import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.workflow.WorkflowHandler;
+
+import java.io.Serializable;
+
+import java.util.Locale;
+import java.util.Map;
+
+import javax.portlet.PortletRequest;
+import javax.portlet.PortletResponse;
+import javax.portlet.PortletURL;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * @author Adolfo Pérez
+ */
+public class WorkflowHandlerWrapper<T> implements WorkflowHandler<T> {
+
+	public WorkflowHandlerWrapper(WorkflowHandler<T> workflowHandler) {
+		_workflowHandler = workflowHandler;
+	}
+
+	@Override
+	public AssetRenderer<T> getAssetRenderer(long classPK)
+		throws PortalException {
+
+		return _workflowHandler.getAssetRenderer(classPK);
+	}
+
+	@Override
+	public AssetRendererFactory<T> getAssetRendererFactory() {
+		return _workflowHandler.getAssetRendererFactory();
+	}
+
+	@Override
+	public String getClassName() {
+		return _workflowHandler.getClassName();
+	}
+
+	@Override
+	public String getIconCssClass() {
+		return _workflowHandler.getIconCssClass();
+	}
+
+	@Override
+	public String getSummary(
+		long classPK, PortletRequest portletRequest,
+		PortletResponse portletResponse) {
+
+		return _workflowHandler.getSummary(
+			classPK, portletRequest, portletResponse);
+	}
+
+	@Override
+	public String getTitle(long classPK, Locale locale) {
+		return _workflowHandler.getTitle(classPK, locale);
+	}
+
+	@Override
+	public String getType(Locale locale) {
+		return _workflowHandler.getType(locale);
+	}
+
+	@Override
+	public PortletURL getURLEdit(
+		long classPK, LiferayPortletRequest liferayPortletRequest,
+		LiferayPortletResponse liferayPortletResponse) {
+
+		return _workflowHandler.getURLEdit(
+			classPK, liferayPortletRequest, liferayPortletResponse);
+	}
+
+	@Override
+	public String getURLEditWorkflowTask(
+			long workflowTaskId, ServiceContext serviceContext)
+		throws PortalException {
+
+		return _workflowHandler.getURLEditWorkflowTask(
+			workflowTaskId, serviceContext);
+	}
+
+	@Override
+	public PortletURL getURLViewDiffs(
+		long classPK, LiferayPortletRequest liferayPortletRequest,
+		LiferayPortletResponse liferayPortletResponse) {
+
+		return _workflowHandler.getURLViewDiffs(
+			classPK, liferayPortletRequest, liferayPortletResponse);
+	}
+
+	@Override
+	public String getURLViewInContext(
+		long classPK, LiferayPortletRequest liferayPortletRequest,
+		LiferayPortletResponse liferayPortletResponse,
+		String noSuchEntryRedirect) {
+
+		return _workflowHandler.getURLViewInContext(
+			classPK, liferayPortletRequest, liferayPortletResponse,
+			noSuchEntryRedirect);
+	}
+
+	@Override
+	public WorkflowDefinitionLink getWorkflowDefinitionLink(
+			long companyId, long groupId, long classPK)
+		throws PortalException {
+
+		return _workflowHandler.getWorkflowDefinitionLink(
+			companyId, groupId, classPK);
+	}
+
+	@Override
+	public boolean include(
+		long classPK, HttpServletRequest httpServletRequest,
+		HttpServletResponse httpServletResponse, String template) {
+
+		return _workflowHandler.include(
+			classPK, httpServletRequest, httpServletResponse, template);
+	}
+
+	@Override
+	public boolean isAssetTypeSearchable() {
+		return _workflowHandler.isAssetTypeSearchable();
+	}
+
+	@Override
+	public boolean isScopeable() {
+		return _workflowHandler.isScopeable();
+	}
+
+	@Override
+	public boolean isVisible() {
+		return _workflowHandler.isVisible();
+	}
+
+	@Override
+	public boolean isVisible(Group group) {
+		return _workflowHandler.isVisible(group);
+	}
+
+	@Override
+	public void startWorkflowInstance(
+			long companyId, long groupId, long userId, long classPK, T model,
+			Map<String, Serializable> workflowContext)
+		throws PortalException {
+
+		_workflowHandler.startWorkflowInstance(
+			companyId, groupId, userId, classPK, model, workflowContext);
+	}
+
+	@Override
+	public T updateStatus(int status, Map<String, Serializable> workflowContext)
+		throws PortalException {
+
+		return _workflowHandler.updateStatus(status, workflowContext);
+	}
+
+	private final WorkflowHandler<T> _workflowHandler;
+
+}

--- a/modules/apps/portal-workflow/portal-workflow-web/src/main/java/com/liferay/portal/workflow/web/internal/display/context/WorkflowDefinitionLinkDisplayContext.java
+++ b/modules/apps/portal-workflow/portal-workflow-web/src/main/java/com/liferay/portal/workflow/web/internal/display/context/WorkflowDefinitionLinkDisplayContext.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.WorkflowDefinitionLink;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
@@ -544,7 +545,9 @@ public class WorkflowDefinitionLinkDisplayContext {
 		List<WorkflowDefinitionLinkSearchEntry>
 			workflowDefinitionLinkSearchEntries = new ArrayList<>();
 
-		for (WorkflowHandler<?> workflowHandler : getWorkflowHandlers()) {
+		for (WorkflowHandler<?> workflowHandler :
+				getWorkflowHandlers(themeDisplay.getScopeGroup())) {
+
 			WorkflowDefinitionLinkSearchEntry
 				workflowDefinitionLinkSearchEntry =
 					createWorkflowDefinitionLinkSearchEntry(
@@ -635,7 +638,7 @@ public class WorkflowDefinitionLinkDisplayContext {
 		}
 	}
 
-	protected List<WorkflowHandler<?>> getWorkflowHandlers() {
+	protected List<WorkflowHandler<?>> getWorkflowHandlers(Group group) {
 		List<WorkflowHandler<?>> workflowHandlers = null;
 
 		if (isControlPanelPortlet()) {
@@ -647,7 +650,9 @@ public class WorkflowDefinitionLinkDisplayContext {
 				WorkflowHandlerRegistryUtil.getScopeableWorkflowHandlers();
 		}
 
-		return ListUtil.filter(workflowHandlers, WorkflowHandler::isVisible);
+		return ListUtil.filter(
+			workflowHandlers,
+			workflowHandler -> workflowHandler.isVisible(group));
 	}
 
 	private String _getCurrentOrder(HttpServletRequest httpServletRequest) {

--- a/portal-kernel/src/com/liferay/portal/kernel/workflow/WorkflowHandler.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/workflow/WorkflowHandler.java
@@ -17,6 +17,7 @@ package com.liferay.portal.kernel.workflow;
 import com.liferay.asset.kernel.model.AssetRenderer;
 import com.liferay.asset.kernel.model.AssetRendererFactory;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.WorkflowDefinitionLink;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
@@ -89,6 +90,10 @@ public interface WorkflowHandler<T> {
 	public boolean isScopeable();
 
 	public boolean isVisible();
+
+	public default boolean isVisible(Group group) {
+		return isVisible();
+	}
 
 	public void startWorkflowInstance(
 			long companyId, long groupId, long userId, long classPK, T model,

--- a/portal-kernel/src/com/liferay/portal/kernel/workflow/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/workflow/packageinfo
@@ -1,1 +1,1 @@
-version 9.3.0
+version 9.4.0


### PR DESCRIPTION
Hey @inacionery !

A bit of context on this PR:

In Asset Libraries, administrators can choose which applications are available. So, it is possible to have an Asset Library with no support for Documents & Media, for example.

When an application is disabled, we don't want it to show up in the WF configuration. To make that possible, I had to create a new "isVisible()" method in the WF handler interface. That method gets the current group as argument, and decides whether or not the WF handler is visible there.

Let me know what do you think about this change.

Thanks!