### PR TITLE
[TS] LPS-112693

### DIFF
--- a/modules/apps/calendar/calendar-api/src/main/java/com/liferay/calendar/util/RecurrenceUtil.java
+++ b/modules/apps/calendar/calendar-api/src/main/java/com/liferay/calendar/util/RecurrenceUtil.java
@@ -273,8 +273,12 @@ public class RecurrenceUtil {
 		List<CalendarBooking> calendarBookingInstances = expandCalendarBooking(
 			calendarBooking, calendarBooking.getStartTime(), Long.MAX_VALUE, 0);
 
-		return calendarBookingInstances.get(
-			calendarBookingInstances.size() - 1);
+		if (!calendarBookingInstances.isEmpty()) {
+			return calendarBookingInstances.get(
+				calendarBookingInstances.size() - 1);
+		}
+
+		return calendarBooking;
 	}
 
 	protected static boolean hasLimit(Recurrence recurrence) {

--- a/modules/apps/calendar/calendar-service/src/test/java/com/liferay/calendar/util/RecurrenceUtilTest.java
+++ b/modules/apps/calendar/calendar-service/src/test/java/com/liferay/calendar/util/RecurrenceUtilTest.java
@@ -95,6 +95,47 @@ public class RecurrenceUtilTest {
 	}
 
 	@Test
+	public void testGetLastCalendarBookingInstanceBetweenCalendarBookingsWithSameRecurringCalendarBookingIdAndExceptionOnFirst() {
+		Calendar lastInstanceStartTimeJCalendar = getJan2016Calendar(2);
+
+		List<CalendarBooking> calendarBookings = getRecurringCalendarBookings(
+			getJan2016Calendar(1),
+			"RRULE:FREQ=DAILY;INTERVAL=1;UNTIL=20160101\n" +
+				"EXDATE;TZID=\"UTC\";VALUE=DATE:20160101",
+			lastInstanceStartTimeJCalendar,
+			"RRULE:FREQ=DAILY;INTERVAL=1;UNTIL=20160103\n" +
+				"EXDATE;TZID=\"UTC\";VALUE=DATE:20160101");
+
+		CalendarBooking calendarBooking20160101 = calendarBookings.get(0);
+		CalendarBooking calendarBooking20160102 = calendarBookings.get(1);
+
+		calendarBooking20160102.setRecurringCalendarBookingId(
+			calendarBooking20160101.getRecurringCalendarBookingId());
+
+		try {
+			CalendarBooking lastInstanceCalendarBooking =
+				RecurrenceUtil.getLastInstanceCalendarBooking(calendarBookings);
+
+			Assert.assertEquals(
+				lastInstanceCalendarBooking.getStartTime(),
+				lastInstanceStartTimeJCalendar.getTimeInMillis());
+
+			Recurrence recurrence20160101 =
+				calendarBooking20160101.getRecurrenceObj();
+			Recurrence recurrence20160102 =
+				calendarBooking20160102.getRecurrenceObj();
+
+			assertSameDay(
+				getJan2016Calendar(1), recurrence20160101.getUntilJCalendar());
+			assertSameDay(
+				getJan2016Calendar(3), recurrence20160102.getUntilJCalendar());
+		}
+		catch (ArrayIndexOutOfBoundsException arrayIndexOutOfBoundsException) {
+			Assert.fail();
+		}
+	}
+
+	@Test
 	public void testGetLastCalendarBookingInstanceReturnsUnboundRecurring() {
 		Calendar lastInstanceStartTimeJCalendar = getJan2016Calendar(23);
 


### PR DESCRIPTION
From @jesseyeh-liferay 

> [LPS-112693](https://issues.liferay.com/browse/LPS-112693) accounts for an edge case in which an `ArrayIndexOutOfBoundsException` occurs in the scenario described in the commit message for the included test:
> >1. A calendar event is created on 2016 Jan 01 that repeats until X date
> >2. The event on 2016 Jan 01 is deleted
> >3. The event on 2016 Jan 02 is modified so that it repeats until 2016
> Jan 03
> >...
> 
> To account for the exception, we perform an an empty list check beforehand and return the original `CalendarBooking` being used as input when this check fails.