### PR TITLE
[TS] LPS-113053

### DIFF
--- a/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarBookingLocalServiceImpl.java
+++ b/modules/apps/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarBookingLocalServiceImpl.java
@@ -1396,13 +1396,24 @@ public class CalendarBookingLocalServiceImpl
 			Recurrence recurrenceObj = RecurrenceSerializer.deserialize(
 				recurrence, calendar.getTimeZone());
 
-			if ((recurrenceObj != null) && oldRecurrence.equals(recurrence) &&
-				(recurrenceObj.getCount() > 0)) {
+			if (recurrenceObj != null) {
+				if (oldRecurrence.equals(recurrence)) {
+					if (recurrenceObj.getCount() > 0) {
+						recurrenceObj.setCount(
+							recurrenceObj.getCount() - instanceIndex);
 
-				recurrenceObj.setCount(
-					recurrenceObj.getCount() - instanceIndex);
+						recurrence = RecurrenceSerializer.serialize(
+							recurrenceObj);
+					}
+				}
+				else {
+					List<java.util.Calendar> exceptionJCalendars =
+						recurrenceObj.getExceptionJCalendars();
 
-				recurrence = RecurrenceSerializer.serialize(recurrenceObj);
+					exceptionJCalendars.clear();
+
+					recurrence = RecurrenceSerializer.serialize(recurrenceObj);
+				}
 			}
 
 			updateCalendarBookingsByChanges(

--- a/modules/apps/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/service/test/CalendarBookingLocalServiceTest.java
+++ b/modules/apps/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/service/test/CalendarBookingLocalServiceTest.java
@@ -507,6 +507,53 @@ public class CalendarBookingLocalServiceTest {
 	}
 
 	@Test
+	public void testAddRecurringCalendarBookingAfterDeletingRecurringCalendarBookingInstance()
+		throws Exception {
+
+		ServiceContext serviceContext = createServiceContext();
+
+		CalendarBooking calendarBooking =
+			CalendarBookingTestUtil.addDailyRecurringCalendarBooking(
+				_user, serviceContext);
+
+		long calendarBookingId = calendarBooking.getCalendarBookingId();
+
+		CalendarBookingLocalServiceUtil.deleteCalendarBookingInstance(
+			_user.getUserId(), calendarBooking, 3, false, true);
+
+		calendarBooking = CalendarBookingLocalServiceUtil.fetchCalendarBooking(
+			calendarBookingId);
+
+		Assert.assertNotNull(calendarBooking);
+
+		Recurrence recurrence = calendarBooking.getRecurrenceObj();
+
+		Recurrence newRecurrence = recurrence.clone();
+
+		int recurrenceCount = 4;
+
+		newRecurrence.setCount(recurrenceCount);
+
+		CalendarBooking newCalendarBooking =
+			CalendarBookingLocalServiceUtil.getCalendarBookingInstance(
+				calendarBookingId, 2);
+
+		newCalendarBooking =
+			CalendarBookingTestUtil.
+				updateRecurringCalendarBookingInstanceAndAllFollowing(
+					_user, newCalendarBooking, 0,
+					newCalendarBooking.getTitleMap(),
+					newCalendarBooking.getDescriptionMap(),
+					newCalendarBooking.getStartTime(),
+					newCalendarBooking.getEndTime(),
+					RecurrenceSerializer.serialize(newRecurrence),
+					serviceContext);
+
+		assertCalendarBookingInstancesCount(
+			newCalendarBooking.getCalendarBookingId(), recurrenceCount);
+	}
+
+	@Test
 	public void testAddRecurringCalendarBookingUntilStartTime()
 		throws Exception {
 


### PR DESCRIPTION
From @jesseyeh-liferay:

> [LPS-113053](https://issues.liferay.com/browse/LPS-113053) accounts for an edge case that occurs in the scenario described in the commit message for the included test:
> >1. A calendar event is created on today's date and repeats daily until X date
> >2. The fourth event in the series is deleted
> >3. The third event in the series is edited so that it repeats for four days
> >...
> 
> When the recurrence edit is made in Step 3, a new `CalendarBooking` is created that shares the same `exceptionJCalendars` (representing the deleted event in Step 2) as the original `CalendarBooking`. Since this recurrence edit is independent from that of the original `CalendarBooking`, we clear out the `exceptionJCalendars` in the new `CalendarBooking` so that it does not errorneously skip over the event deleted in Step 2.