### PR TITLE
LPS-116324 Prevent portal-workflow-kaleo-designer-web from applying a…

### DIFF
--- a/modules/apps/petra/petra-xml/src/main/java/com/liferay/petra/xml/Dom4jUtil.java
+++ b/modules/apps/petra/petra-xml/src/main/java/com/liferay/petra/xml/Dom4jUtil.java
@@ -57,10 +57,20 @@ public class Dom4jUtil {
 			boolean trimText)
 		throws IOException {
 
+		return toString(node, indent, expandEmptyElements, trimText, true);
+	}
+
+	public static String toString(
+			Node node, String indent, boolean expandEmptyElements,
+			boolean trimText, boolean usePrettyPrint)
+		throws IOException {
+
 		UnsyncByteArrayOutputStream unsyncByteArrayOutputStream =
 			new UnsyncByteArrayOutputStream();
 
-		OutputFormat outputFormat = OutputFormat.createPrettyPrint();
+		OutputFormat outputFormat =
+			usePrettyPrint ? OutputFormat.createPrettyPrint() :
+				new OutputFormat();
 
 		outputFormat.setExpandEmptyElements(expandEmptyElements);
 		outputFormat.setIndent(indent);

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-definition-impl/src/main/java/com/liferay/portal/workflow/kaleo/definition/internal/parser/XMLWorkflowModelParser.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-definition-impl/src/main/java/com/liferay/portal/workflow/kaleo/definition/internal/parser/XMLWorkflowModelParser.java
@@ -119,7 +119,7 @@ public class XMLWorkflowModelParser implements WorkflowModelParser {
 			rootElement.elementTextTrim("version"));
 
 		Definition definition = new Definition(
-			name, description, document.formattedString(), version);
+			name, description, document.unformattedString(), version);
 
 		List<Element> conditionElements = rootElement.elements("condition");
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/main.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/main.js
@@ -486,8 +486,7 @@ AUI.add(
 					}
 
 					var content = instance.get('definition');
-
-					if (!content || XMLUtil.validateDefinition(content)) {
+					if (!content || !XMLUtil.validateDefinition(content)) {
 						content = instance.getContent();
 					}
 

--- a/portal-impl/src/com/liferay/portal/xml/NodeImpl.java
+++ b/portal-impl/src/com/liferay/portal/xml/NodeImpl.java
@@ -302,6 +302,11 @@ public class NodeImpl implements Node {
 	}
 
 	@Override
+	public String unformattedString() throws Exception {
+		return Dom4jUtil.toString(_node, null, false, false, false);
+	}
+
+	@Override
 	public String valueOf(String xPathExpression) {
 		return _node.valueOf(xPathExpression);
 	}

--- a/portal-kernel/src/com/liferay/portal/kernel/xml/Node.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/xml/Node.java
@@ -94,6 +94,8 @@ public interface Node extends Serializable {
 
 	public boolean supportsParent();
 
+	public String unformattedString() throws Exception;
+
 	public String valueOf(String xPathExpression);
 
 	public void write(Writer writer) throws IOException;


### PR DESCRIPTION
[**LPS-116324**](https://issues.liferay.com/browse/LPS-116324)

Forwarded from https://github.com/wincent/liferay-portal/pull/359 after being reviewed by @wincent

From @jesseyeh-liferay

> **Overview**
> 
> This issue is a follow-up to the solution introduced by [LPS-114933](https://issues.liferay.com/browse/LPS-114933), which prevents formatting from being applied to CDATA blocks (but is limited to CE versions).
> 
> In non-CE versions, the portal-workflow-kaleo-designer-web module applies additional formatting to workflow definitions. The issue is two-fold: first, the module introduces formatting which trims whitespace, resulting in edge cases such as
> 
> ```
> <script>
>     <![CDATA[
>         import com.liferay.portal.kernel.workflow.WorkflowStatusManagerUtil;
>         import com.liferay.portal.kernel.workflow.WorkflowConstants;
> 
>         WorkflowStatusManagerUtil.updateStatus(WorkflowConstants.getLabelStatus("approved"), workflowContext);
>     ]]>
> </script>
> ```
> 
> turning into
> 
> ```
> <script><![CDATA[import com.liferay.portal.kernel.workflow.WorkflowStatusManagerUtil;
>         import com.liferay.portal.kernel.workflow.WorkflowConstants;
> 
>         WorkflowStatusManagerUtil.updateStatus(WorkflowConstants.getLabelStatus("approved"), workflowContext);]]></script>
> ```
> 
> This is due to a [combination of tab, trim, and pretty print settings on the `OutputFormat`](https://github.com/liferay/liferay-portal/blob/master/modules/apps/petra/petra-xml/src/main/java/com/liferay/petra/xml/Dom4jUtil.java#L63-L68).
> 
> Second, there is an [erroneous check that is performed which marks valid XML as invalid](https://github.com/liferay/liferay-portal/blob/6967aa6cfc4d1ffc74f296eecc38c47a5abc2754/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/main.js#L490). This leads to the original XML being reinterpreted (via `getContent()`) and results in further formatting differences.
> 
> **Solution**
> 
> The solution being proposed makes it so that there is an option to use a default `OutputFormat` without any tab, trim, or pretty print settings to preserve the original XML formatting. This is achieved via the newly-introduced `unformattedString()`. Furthermore, this solution inverts the aforementioned conditional so that valid XML is not marked otherwise.