### PR TITLE
LPS-119232: Update workflow context for KaleoTimerInstanceToken

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/action/KaleoActionExecutorImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/action/KaleoActionExecutorImpl.java
@@ -21,12 +21,15 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.workflow.kaleo.definition.ExecutionType;
 import com.liferay.portal.workflow.kaleo.model.KaleoAction;
 import com.liferay.portal.workflow.kaleo.model.KaleoInstanceToken;
+import com.liferay.portal.workflow.kaleo.model.KaleoTimerInstanceToken;
 import com.liferay.portal.workflow.kaleo.runtime.ExecutionContext;
 import com.liferay.portal.workflow.kaleo.runtime.action.ActionExecutorManager;
 import com.liferay.portal.workflow.kaleo.runtime.action.KaleoActionExecutor;
+import com.liferay.portal.workflow.kaleo.runtime.util.WorkflowContextUtil;
 import com.liferay.portal.workflow.kaleo.service.KaleoActionLocalService;
 import com.liferay.portal.workflow.kaleo.service.KaleoInstanceLocalService;
 import com.liferay.portal.workflow.kaleo.service.KaleoLogLocalService;
+import com.liferay.portal.workflow.kaleo.service.KaleoTimerInstanceTokenLocalService;
 
 import java.util.List;
 
@@ -67,6 +70,18 @@ public class KaleoActionExecutorImpl implements KaleoActionExecutor {
 				_kaleoInstanceLocalService.updateKaleoInstance(
 					kaleoInstanceToken.getKaleoInstanceId(),
 					executionContext.getWorkflowContext(), serviceContext);
+
+				final KaleoTimerInstanceToken kaleoTimerInstanceToken =
+					executionContext.getKaleoTimerInstanceToken();
+
+				if (kaleoTimerInstanceToken != null) {
+					kaleoTimerInstanceToken.setWorkflowContext(
+						WorkflowContextUtil.convert(
+							executionContext.getWorkflowContext()));
+
+					_kaleoTimerInstanceTokenLocalService.
+						updateKaleoTimerInstanceToken(kaleoTimerInstanceToken);
+				}
 			}
 			catch (Exception exception) {
 				_log.error(exception, exception);
@@ -99,5 +114,9 @@ public class KaleoActionExecutorImpl implements KaleoActionExecutor {
 
 	@Reference
 	private KaleoLogLocalService _kaleoLogLocalService;
+
+	@Reference
+	private KaleoTimerInstanceTokenLocalService
+		_kaleoTimerInstanceTokenLocalService;
 
 }


### PR DESCRIPTION
From @binhtran92
> Workflow context is both using at task action and timer action. So there is a missing update workflow context for timer action.