### PR TITLE
WIP

### DIFF
--- a/modules/sdk/gradle-plugins-python/build.gradle
+++ b/modules/sdk/gradle-plugins-python/build.gradle
@@ -6,7 +6,7 @@ tasks.eclipse {
 
 dependencies {
 	compile group: "com.liferay", name: "com.liferay.gradle.util", version: "1.0.44"
-	compile group: "com.pswidersk", name: "python-gradle-plugin", version: "1.2.1"
+	compile group: "com.pswidersk", name: "python-gradle-plugin", version: "1.2.2"
 
 	compileOnly fileTree(builtBy: [rootProject.tasks.getByName("extractGradleApi" + gradleVersion.replace(".", ""))], dir: new File(rootProject.buildDir, "gradle-${gradleVersion}"))
 }

--- a/modules/sdk/gradle-plugins-python/build.gradle
+++ b/modules/sdk/gradle-plugins-python/build.gradle
@@ -7,6 +7,7 @@ tasks.eclipse {
 dependencies {
 	compile group: "com.liferay", name: "com.liferay.gradle.util", version: "1.0.44"
 	compile group: "com.pswidersk", name: "python-gradle-plugin", version: "1.2.2"
+	
 
 	compileOnly fileTree(builtBy: [rootProject.tasks.getByName("extractGradleApi" + gradleVersion.replace(".", ""))], dir: new File(rootProject.buildDir, "gradle-${gradleVersion}"))
 }


### PR DESCRIPTION
Forwarded from: https://github.com/inacionery/liferay-portal/pull/4917 (Took 2 `ci:forward` attempts in 10 hours 18 minutes)

@inacionery



<html><h3>:heavy_check_mark: ci:test:stable - 20 out of 20 jobs passed</h3><h3>:heavy_check_mark: ci:test:relevant - 60 out of 63 jobs passed in 2 hours 32 minutes</h3><details><summary>Click here for more details.</summary><h4>Base Branch:</h4><p>Branch Name: <a href="https://github.com/liferay/liferay-portal/tree/master">master</a><br/>Branch GIT ID: <a href="https://github.com/liferay/liferay-portal/commit/f193301b2848899b008d51513af62a3b3a9b7888">f193301b2848899b008d51513af62a3b3a9b7888</a></p><h4>Copied in Private Modules Branch:</h4><p>Branch Name: <a href="https://github.com/liferay/liferay-portal-ee/tree/master-private">master-private</a><br/>Branch GIT ID: <a href="https://github.com/liferay/liferay-portal-ee/commit/13c59df02738cba7c7387b3490775720676498c7">13c59df02738cba7c7387b3490775720676498c7</a></p><details><summary><strong>ci:test:stable - 20 out of 20 jobs PASSED</strong></summary><details><summary><strong>20 Successful Jobs:</strong></summary><ul><li><a href="https://test-1-21.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/388182/">test-portal-acceptance-pullrequest-batch(master)/functional-smoke-tomcat90-mysql57-jdk8_stable/0</a></li><li><a href="https://test-1-16.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/447616/">test-portal-acceptance-pullrequest-batch(master)/functional-upgrade-tomcat90-mysql57-jdk8_stable/0</a></li><li><a href="https://test-1-4.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/445620/">test-portal-acceptance-pullrequest-batch(master)/functional-upgrade-tomcat90-mysql57-jdk8_stable/1</a></li><li><a href="https://test-1-7.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/418897/">test-portal-acceptance-pullrequest-batch(master)/functional-upgrade-tomcat90-mysql57-jdk8_stable/10</a></li><li><a href="https://test-1-6.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/440240/">test-portal-acceptance-pullrequest-batch(master)/functional-upgrade-tomcat90-mysql57-jdk8_stable/11</a></li><li><a href="https://test-1-12.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/331383/">test-portal-acceptance-pullrequest-batch(master)/functional-upgrade-tomcat90-mysql57-jdk8_stable/2</a></li><li><a href="https://test-1-8.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/408386/">test-portal-acceptance-pullrequest-batch(master)/functional-upgrade-tomcat90-mysql57-jdk8_stable/3</a></li><li><a href="https://test-1-5.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/438133/">test-portal-acceptance-pullrequest-batch(master)/functional-upgrade-tomcat90-mysql57-jdk8_stable/4</a></li><li><a href="https://test-1-19.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/436163/">test-portal-acceptance-pullrequest-batch(master)/functional-upgrade-tomcat90-mysql57-jdk8_stable/5</a></li><li><a href="https://test-1-21.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/388189/">test-portal-acceptance-pullrequest-batch(master)/functional-upgrade-tomcat90-mysql57-jdk8_stable/6</a></li><li><a href="https://test-1-20.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/425277/">test-portal-acceptance-pullrequest-batch(master)/functional-upgrade-tomcat90-mysql57-jdk8_stable/7</a></li><li><a href="https://test-1-6.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/440241/">test-portal-acceptance-pullrequest-batch(master)/functional-upgrade-tomcat90-mysql57-jdk8_stable/8</a></li><li><a href="https://test-1-7.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/418898/">test-portal-acceptance-pullrequest-batch(master)/functional-upgrade-tomcat90-mysql57-jdk8_stable/9</a></li><li><a href="https://test-1-15.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/311787/">test-portal-acceptance-pullrequest-batch(master)/js-unit-jdk8</a></li><li><a href="https://test-1-18.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/199437/">test-portal-acceptance-pullrequest-batch(master)/modules-integration-mysql57-jdk8_stable</a></li><li><a href="https://test-1-4.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/445619/">test-portal-acceptance-pullrequest-batch(master)/modules-unit-jdk8_stable</a></li><li><a href="https://test-1-15.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/311786/">test-portal-acceptance-pullrequest-batch(master)/pmd-jdk8</a></li><li><a href="https://test-1-22.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/306273/">test-portal-acceptance-pullrequest-batch(master)/rest-builder-jdk8</a></li><li><a href="https://test-1-21.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/388186/">test-portal-acceptance-pullrequest-batch(master)/service-builder-jdk8</a></li><li><a href="https://test-1-8.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/408391/">test-portal-acceptance-pullrequest-batch(master)/unit-jdk8_stable</a></li></ul></details></details><details><summary><strong>ci:test:relevant - 59 out of 63 jobs PASSED</strong></summary><div><h4>4 Failed Jobs:</h4><ul><li><a href="https://test-1-21.liferay.com/job/test-portal-acceptance-pullrequest(master)/6973/"><strike><strong>test-portal-acceptance-pullrequest(master)</strong></strike></a></li><li><a href="https://test-1-10.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/361755/"><strike><strong>test-portal-acceptance-pullrequest-batch(master)/functional-tomcat90-mysql57-jdk8/1</strong></strike></a></li><li><a href="https://test-1-13.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/408257/"><strike><strong>test-portal-acceptance-pullrequest-batch(master)/functional-tomcat90-mysql57-jdk8/2</strong></strike></a></li><li><a href="https://test-1-16.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/447613/"><strike><strong>test-portal-acceptance-pullrequest-batch(master)/functional-tomcat90-mysql57-jdk8/3</strong></strike></a></li></ul></div><details><summary><strong>59 Successful Jobs:</strong></summary><ul><li><a href="https://test-1-18.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/199438/">test-portal-acceptance-pullrequest-batch(master)/central-requirements-jdk8</a></li><li><a href="https://test-1-22.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/306277/">test-portal-acceptance-pullrequest-batch(master)/functional-smoke-tomcat90-mysql57-jdk11_open/0</a></li><li><a href="https://test-1-21.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/388182/">test-portal-acceptance-pullrequest-batch(master)/functional-smoke-tomcat90-mysql57-jdk8_stable/0</a></li><li><a href="https://test-1-5.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/438131/">test-portal-acceptance-pullrequest-batch(master)/functional-tomcat90-mysql57-jdk8/0</a></li><li><a href="https://test-1-6.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/440239/">test-portal-acceptance-pullrequest-batch(master)/functional-tomcat90-mysql57-jdk8/10</a></li><li><a href="https://test-1-21.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/388187/">test-portal-acceptance-pullrequest-batch(master)/functional-tomcat90-mysql57-jdk8/11</a></li><li><a href="https://test-1-16.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/447614/">test-portal-acceptance-pullrequest-batch(master)/functional-tomcat90-mysql57-jdk8/12</a></li><li><a href="https://test-1-8.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/408389/">test-portal-acceptance-pullrequest-batch(master)/functional-tomcat90-mysql57-jdk8/13</a></li><li><a href="https://test-1-6.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/440238/">test-portal-acceptance-pullrequest-batch(master)/functional-tomcat90-mysql57-jdk8/14</a></li><li><a href="https://test-1-20.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/425276/">test-portal-acceptance-pullrequest-batch(master)/functional-tomcat90-mysql57-jdk8/15</a></li><li><a href="https://test-1-19.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/436162/">test-portal-acceptance-pullrequest-batch(master)/functional-tomcat90-mysql57-jdk8/16</a></li><li><a href="https://test-1-7.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/418896/">test-portal-acceptance-pullrequest-batch(master)/functional-tomcat90-mysql57-jdk8/17</a></li><li><a href="https://test-1-22.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/306275/">test-portal-acceptance-pullrequest-batch(master)/functional-tomcat90-mysql57-jdk8/18</a></li><li><a href="https://test-1-4.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/445618/">test-portal-acceptance-pullrequest-batch(master)/functional-tomcat90-mysql57-jdk8/19</a></li><li><a href="https://test-1-7.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/418895/">test-portal-acceptance-pullrequest-batch(master)/functional-tomcat90-mysql57-jdk8/4</a></li><li><a href="https://test-1-4.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/445617/">test-portal-acceptance-pullrequest-batch(master)/functional-tomcat90-mysql57-jdk8/5</a></li><li><a href="https://test-1-22.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/306274/">test-portal-acceptance-pullrequest-batch(master)/functional-tomcat90-mysql57-jdk8/6</a></li><li><a href="https://test-1-8.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/408388/">test-portal-acceptance-pullrequest-batch(master)/functional-tomcat90-mysql57-jdk8/7</a></li><li><a href="https://test-1-10.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/361754/">test-portal-acceptance-pullrequest-batch(master)/functional-tomcat90-mysql57-jdk8/8</a></li><li><a href="https://test-1-6.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/440237/">test-portal-acceptance-pullrequest-batch(master)/functional-tomcat90-mysql57-jdk8/9</a></li><li><a href="https://test-1-8.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/408387/">test-portal-acceptance-pullrequest-batch(master)/functional-upgrade-tomcat90-mysql57-jdk8/0</a></li><li><a href="https://test-1-6.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/440236/">test-portal-acceptance-pullrequest-batch(master)/functional-upgrade-tomcat90-mysql57-jdk8/1</a></li><li><a href="https://test-1-8.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/408390/">test-portal-acceptance-pullrequest-batch(master)/functional-upgrade-tomcat90-mysql57-jdk8/10</a></li><li><a href="https://test-1-5.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/438132/">test-portal-acceptance-pullrequest-batch(master)/functional-upgrade-tomcat90-mysql57-jdk8/11</a></li><li><a href="https://test-1-21.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/388184/">test-portal-acceptance-pullrequest-batch(master)/functional-upgrade-tomcat90-mysql57-jdk8/2</a></li><li><a href="https://test-1-18.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/199436/">test-portal-acceptance-pullrequest-batch(master)/functional-upgrade-tomcat90-mysql57-jdk8/3</a></li><li><a href="https://test-1-7.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/418894/">test-portal-acceptance-pullrequest-batch(master)/functional-upgrade-tomcat90-mysql57-jdk8/4</a></li><li><a href="https://test-1-21.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/388185/">test-portal-acceptance-pullrequest-batch(master)/functional-upgrade-tomcat90-mysql57-jdk8/5</a></li><li><a href="https://test-1-19.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/436161/">test-portal-acceptance-pullrequest-batch(master)/functional-upgrade-tomcat90-mysql57-jdk8/6</a></li><li><a href="https://test-1-6.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/440235/">test-portal-acceptance-pullrequest-batch(master)/functional-upgrade-tomcat90-mysql57-jdk8/7</a></li><li><a href="https://test-1-20.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/425275/">test-portal-acceptance-pullrequest-batch(master)/functional-upgrade-tomcat90-mysql57-jdk8/8</a></li><li><a href="https://test-1-21.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/388183/">test-portal-acceptance-pullrequest-batch(master)/functional-upgrade-tomcat90-mysql57-jdk8/9</a></li><li><a href="https://test-1-16.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/447616/">test-portal-acceptance-pullrequest-batch(master)/functional-upgrade-tomcat90-mysql57-jdk8_stable/0</a></li><li><a href="https://test-1-4.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/445620/">test-portal-acceptance-pullrequest-batch(master)/functional-upgrade-tomcat90-mysql57-jdk8_stable/1</a></li><li><a href="https://test-1-7.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/418897/">test-portal-acceptance-pullrequest-batch(master)/functional-upgrade-tomcat90-mysql57-jdk8_stable/10</a></li><li><a href="https://test-1-6.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/440240/">test-portal-acceptance-pullrequest-batch(master)/functional-upgrade-tomcat90-mysql57-jdk8_stable/11</a></li><li><a href="https://test-1-12.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/331383/">test-portal-acceptance-pullrequest-batch(master)/functional-upgrade-tomcat90-mysql57-jdk8_stable/2</a></li><li><a href="https://test-1-8.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/408386/">test-portal-acceptance-pullrequest-batch(master)/functional-upgrade-tomcat90-mysql57-jdk8_stable/3</a></li><li><a href="https://test-1-5.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/438133/">test-portal-acceptance-pullrequest-batch(master)/functional-upgrade-tomcat90-mysql57-jdk8_stable/4</a></li><li><a href="https://test-1-19.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/436163/">test-portal-acceptance-pullrequest-batch(master)/functional-upgrade-tomcat90-mysql57-jdk8_stable/5</a></li><li><a href="https://test-1-21.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/388189/">test-portal-acceptance-pullrequest-batch(master)/functional-upgrade-tomcat90-mysql57-jdk8_stable/6</a></li><li><a href="https://test-1-20.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/425277/">test-portal-acceptance-pullrequest-batch(master)/functional-upgrade-tomcat90-mysql57-jdk8_stable/7</a></li><li><a href="https://test-1-6.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/440241/">test-portal-acceptance-pullrequest-batch(master)/functional-upgrade-tomcat90-mysql57-jdk8_stable/8</a></li><li><a href="https://test-1-7.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/418898/">test-portal-acceptance-pullrequest-batch(master)/functional-upgrade-tomcat90-mysql57-jdk8_stable/9</a></li><li><a href="https://test-1-15.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/311787/">test-portal-acceptance-pullrequest-batch(master)/js-unit-jdk8</a></li><li><a href="https://test-1-22.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/306272/">test-portal-acceptance-pullrequest-batch(master)/lpkg-base-jdk8</a></li><li><a href="https://test-1-22.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/306276/">test-portal-acceptance-pullrequest-batch(master)/lpkg-controller-jdk8</a></li><li><a href="https://test-1-13.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/408258/">test-portal-acceptance-pullrequest-batch(master)/modules-compile-jdk8</a></li><li><a href="https://test-1-15.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/311788/">test-portal-acceptance-pullrequest-batch(master)/modules-integration-mysql57-jdk8</a></li><li><a href="https://test-1-18.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/199437/">test-portal-acceptance-pullrequest-batch(master)/modules-integration-mysql57-jdk8_stable</a></li><li><a href="https://test-1-16.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/447615/">test-portal-acceptance-pullrequest-batch(master)/modules-semantic-versioning-jdk8</a></li><li><a href="https://test-1-19.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/436164/">test-portal-acceptance-pullrequest-batch(master)/modules-unit-jdk8</a></li><li><a href="https://test-1-4.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/445619/">test-portal-acceptance-pullrequest-batch(master)/modules-unit-jdk8_stable</a></li><li><a href="https://test-1-15.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/311786/">test-portal-acceptance-pullrequest-batch(master)/pmd-jdk8</a></li><li><a href="https://test-1-22.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/306273/">test-portal-acceptance-pullrequest-batch(master)/rest-builder-jdk8</a></li><li><a href="https://test-1-21.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/388188/">test-portal-acceptance-pullrequest-batch(master)/semantic-versioning-jdk8</a></li><li><a href="https://test-1-21.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/388186/">test-portal-acceptance-pullrequest-batch(master)/service-builder-jdk8</a></li><li><a href="https://test-1-24.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/6127/">test-portal-acceptance-pullrequest-batch(master)/unit-jdk8</a></li><li><a href="https://test-1-8.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/408391/">test-portal-acceptance-pullrequest-batch(master)/unit-jdk8_stable</a></li></ul></details></details><h5>For more details click <a href="https://test-1-21.liferay.com/userContent/jobs/test-portal-acceptance-pullrequest(master)/builds/6973/jenkins-report.html">here</a>.</h5><hr/><h4>This pull contains no unique failures.</h4><hr/><details><summary><strong>Failures in common with <a href="https://test-1-1.liferay.com/job/test-portal-acceptance-upstream-dxp(master)">acceptance upstream results</a> at f193301b2848899b008d51513af62a3b3a9b7888:</strong></summary><ol><li><div><h5><a href="https://test-1-10.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/361755/">test-portal-acceptance-pullrequest-batch(master)/functional-tomcat90-mysql57-jdk8/1</a></h5><div><h6>Job Results:</h6><p>18 Tests Passed.<br/>1 Test Failed.</p></div><ol><li><div><a href="https://test-1-10.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/AXIS_VARIABLE=0,label_exp=!master/361755//consoleText">AXIS_VARIABLE=0,label_exp=!master #361755</a><ol><li><div><a href="https://test-1-10.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/AXIS_VARIABLE=0,label_exp=!master/361755//testReport/com.liferay.poshi.runner/PoshiRunner/test_LocalFile_AssetPublisherWithWebContent_ViewWebContentViaAPAsGuestWithViewPermission_">LocalFile.AssetPublisherWithWebContent#ViewWebContentViaAPAsGuestWithViewPermission</a> - <a href="https://testray.liferay.com/reports/production/logs/test-1-21/1601544815982/test-portal-acceptance-pullrequest(master)/6973/functional-tomcat90-mysql57-jdk8/1/0/LocalFile.AssetPublisherWithWebContent_ViewWebContentViaAPAsGuestWithViewPermission/index.html.gz">Poshi Report</a> - <a href="https://testray.liferay.com/reports/production/logs/test-1-21/1601544815982/test-portal-acceptance-pullrequest(master)/6973/functional-tomcat90-mysql57-jdk8/1/0/LocalFile.AssetPublisherWithWebContent_ViewWebContentViaAPAsGuestWithViewPermission/summary.html.gz">Poshi Summary</a> - <a href="https://testray.liferay.com/reports/production/logs/test-1-21/1601544815982/test-portal-acceptance-pullrequest(master)/6973/functional-tomcat90-mysql57-jdk8/1/0/jenkins-console.txt.gz">Console Output</a></div></li></ol></div></li></ol></div></li><li><div><h5><a href="https://test-1-13.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/408257/">test-portal-acceptance-pullrequest-batch(master)/functional-tomcat90-mysql57-jdk8/2</a></h5><div><h6>Job Results:</h6><p>17 Tests Passed.<br/>1 Test Failed.</p></div><ol><li><div><a href="https://test-1-13.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/AXIS_VARIABLE=0,label_exp=!master/408257//consoleText">AXIS_VARIABLE=0,label_exp=!master #408257</a><ol><li><div><a href="https://test-1-13.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/AXIS_VARIABLE=0,label_exp=!master/408257//testReport/com.liferay.poshi.runner/PoshiRunner/test_LocalFile_WebContentExportImport_AddWebContentFromImportedStructureAndTemplate_">LocalFile.WebContentExportImport#AddWebContentFromImportedStructureAndTemplate</a> - <a href="https://testray.liferay.com/reports/production/logs/test-1-21/1601544815982/test-portal-acceptance-pullrequest(master)/6973/functional-tomcat90-mysql57-jdk8/2/0/LocalFile.WebContentExportImport_AddWebContentFromImportedStructureAndTemplate/index.html.gz">Poshi Report</a> - <a href="https://testray.liferay.com/reports/production/logs/test-1-21/1601544815982/test-portal-acceptance-pullrequest(master)/6973/functional-tomcat90-mysql57-jdk8/2/0/LocalFile.WebContentExportImport_AddWebContentFromImportedStructureAndTemplate/summary.html.gz">Poshi Summary</a> - <a href="https://testray.liferay.com/reports/production/logs/test-1-21/1601544815982/test-portal-acceptance-pullrequest(master)/6973/functional-tomcat90-mysql57-jdk8/2/0/jenkins-console.txt.gz">Console Output</a></div></li></ol></div></li></ol></div></li><li><div><h5><a href="https://test-1-16.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/447613/">test-portal-acceptance-pullrequest-batch(master)/functional-tomcat90-mysql57-jdk8/3</a></h5><div><h6>Job Results:</h6><p>1 Test Passed.<br/>1 Test Failed.</p></div><ol><li><div><a href="https://test-1-16.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/AXIS_VARIABLE=0,label_exp=!master/447613//consoleText">AXIS_VARIABLE=0,label_exp=!master #447613</a><ol><li><div><a href="https://test-1-16.liferay.com/job/test-portal-acceptance-pullrequest-batch(master)/AXIS_VARIABLE=0,label_exp=!master/447613//testReport/com.liferay.poshi.runner/PoshiRunner/test_LocalFile_WebContentWithPermissions_AddAndViewStructureAndTemplateWithPermissions_">LocalFile.WebContentWithPermissions#AddAndViewStructureAndTemplateWithPermissions</a> - <a href="https://testray.liferay.com/reports/production/logs/test-1-21/1601544815982/test-portal-acceptance-pullrequest(master)/6973/functional-tomcat90-mysql57-jdk8/3/0/LocalFile.WebContentWithPermissions_AddAndViewStructureAndTemplateWithPermissions/index.html.gz">Poshi Report</a> - <a href="https://testray.liferay.com/reports/production/logs/test-1-21/1601544815982/test-portal-acceptance-pullrequest(master)/6973/functional-tomcat90-mysql57-jdk8/3/0/LocalFile.WebContentWithPermissions_AddAndViewStructureAndTemplateWithPermissions/summary.html.gz">Poshi Summary</a> - <a href="https://testray.liferay.com/reports/production/logs/test-1-21/1601544815982/test-portal-acceptance-pullrequest(master)/6973/functional-tomcat90-mysql57-jdk8/3/0/jenkins-console.txt.gz">Console Output</a></div></li></ol></div></li></ol></div></li></ol></details></details></html>


<html><h3>:heavy_check_mark: ci:test:sf - 1 out of 1 jobs passed in 3 minutes</h3><details><summary>Click here for more details.</summary><h4>Base Branch:</h4><p>Branch Name: <a href="https://github.com/liferay/liferay-portal/tree/master">master</a><br/>Branch GIT ID: <a href="https://github.com/liferay/liferay-portal/commit/f193301b2848899b008d51513af62a3b3a9b7888">f193301b2848899b008d51513af62a3b3a9b7888</a></p><h4>Sender Branch:</h4><p>Branch Name: <a href="https://github.com/inacionery/liferay-portal/tree/LPS-119446">LPS-119446</a><br/>Branch GIT ID: <a href="https://github.com/inacionery/liferay-portal/commit/9bcdea56f336f481f60a4f1fd6edf4c8b31981d7">9bcdea56f336f481f60a4f1fd6edf4c8b31981d7</a></p>1 out of 1jobs PASSED<details><summary><strong>1 Successful Jobs:</strong></summary><ul><li><a href="https://test-1-12.liferay.com/job/test-portal-source-format/2526/">test-portal-source-format</a></li></ul></details><h5>For more details click <a href="https://test-1-12.liferay.com/userContent/jobs/test-portal-source-format/builds/2526/jenkins-report.html">here</a>.</h5></details></html>